### PR TITLE
Change how the border inset shadow is created so that it is rendered …

### DIFF
--- a/html/css/style.css
+++ b/html/css/style.css
@@ -371,10 +371,21 @@
     overflow-y: auto;
     background-image: url(../images/BG.png);
     background-repeat: repeat;
+
+}
+
+#main-shadow-effect {
+    position: fixed;
+    top: 72px;
+    bottom: 7px;
+    left: 7px;
+	right: 32px;
     box-shadow: inset 0px 13px 15px -10px rgba(0,0,0,1),
-                inset 0px -13px 15px -10px rgba(0,0,0,1),
-                inset 13px 0px 15px -10px rgba(0,0,0,1),
-                inset -13px 0px 15px -10px rgba(0,0,0,1);
+				inset 0px -13px 15px -10px rgba(0,0,0,1),
+				inset 13px 0px 15px -10px rgba(0,0,0,1),
+				inset -13px 0px 15px -10px rgba(0,0,0,1);
+	pointer-events: none;
+	z-index: 10;
 }
 
 .main-notice {
@@ -386,7 +397,6 @@
 
 .scroll-style::-webkit-scrollbar {
     width: 25px;
-    box-shadow: -6px 0px 15px 0px rgba(0,0,0,1);
 }
 .scroll-style::-webkit-scrollbar-track {
     background-color: #1c1c1c;    

--- a/html/index.html
+++ b/html/index.html
@@ -63,7 +63,8 @@
                 </div>
 
     <!-------------------------------------------------------------------------------- Build the Main View container ---------->
-                <div class="main-container scroll-style">
+				<div class="main-container scroll-style">
+					<div id="main-shadow-effect"></div>
                     <div class="container-fluid" v-if="page === 'modlist'">
                         <kn-mod v-for="mod in mods" :key="mod.id" :mod="mod" :tab="tab"></kn-mod>
                         <div v-if="mods.length === 0" class="main-notice">No mods found.</div>


### PR DESCRIPTION
This PR is not ready, but I wanted you to take a look because I thought you might be able to whip up a quick fix. 

This switches around the box-shadow for the main container so it's rendered on top of child elements. However, doing so requires position:fixed, and thus I need a javascript solution to apply the width of the scrollbar to the div attribute "Right" when the scrollbar is present to fix the visual bug.

`#main-shadow-effect {
    right: 7px;`

Should become...
`#main-shadow-effect {
    right: 32px;`

When the scrollbar is rendered, else, revert to the previous.