### PR TITLE
Fix crash if KN_DEBUG isn't set

### DIFF
--- a/knossos/center.py
+++ b/knossos/center.py
@@ -26,7 +26,12 @@ from .qt import QtCore
 VERSION = '0.5.0-dev'
 UPDATE_LINK = 'https://dev.tproxy.de/knossos'
 INNOEXTRACT_LINK = 'https://dev.tproxy.de/knossos/innoextract.txt'
-DEBUG = os.environ.get('KN_DEBUG').strip() == '1'
+try:
+    DEBUG = os.environ['KN_DEBUG'].strip() == '1'
+except KeyError:
+    DEBUG = False
+except:
+    raise
 SENTRY_DSN = 'https://77179552b41946488346a9a2d2669d74:f7b896367bd94f0ea960b8f0ee8b7a88@sentry.gruenprint.de/9?timeout=5'
 
 LANGUAGES = {


### PR DESCRIPTION
I removed the .get() so that the except could trigger on KeyError rather than the more generic AttributeError (at least I _think_ AttributeError is more generic)