### PR TITLE
Hide tool buttons for engine mods

### DIFF
--- a/html/templates/kn-mod-home.vue
+++ b/html/templates/kn-mod-home.vue
@@ -91,7 +91,7 @@ export default {
                     </button>
 
                     <kn-dropdown @open="updateTools(); open = true" @close="open = false">
-                        <button v-for="tool in tools" @click="launchTool(tool)">Run {{ tool }}</button>
+                        <button v-for="tool in tools" v-if="mod.installed && (mod.status === 'ready' || mod.status === 'update') && (mod.type === 'mod' || mod.type == 'tc')" @click="launchTool(tool)">Run {{ tool }}</button>
                         <button @click="uploadLog">Upload Debug Log</button>
                         <button v-if="mod.id !== 'FS2' && mod.status !== 'updating'" @click="install">Modify</button>
                         <button v-if="mod.id !== 'FS2' && mod.status !== 'updating' && !mod.dev_mode" @click="uninstallMod">Uninstall</button>


### PR DESCRIPTION
They don't work anyway so there is no point in showing them for engine
mods.