### PR TITLE
Add support for limiting download bandwidth

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -13,4 +13,5 @@ raven = "*"
 pyqt5 = "*"
 requests-toolbelt = "*"
 ply = "*"
+token-bucket = "*"
 

--- a/html/templates/kn-settings-page.vue
+++ b/html/templates/kn-settings-page.vue
@@ -44,7 +44,7 @@ export default {
         save() {
             this.fso.joystick_ff_strength = this.ff_enabled ? 100 : 0;
 
-            for(let set of ['base_path', 'max_downloads', 'use_raven', 'engine_stability']) {
+            for(let set of ['base_path', 'max_downloads', 'use_raven', 'engine_stability', 'download_bandwidth']) {
                 if(this.knossos[set] != this.old_settings.knossos[set]) {
                     fs2mod.saveSetting(set, JSON.stringify(this.knossos[set]));
                 }
@@ -90,19 +90,12 @@ export default {
             <div class="settings-exp">Click the arrows to reveal each group's options. Click SAVE when done.</div>
 
             <kn-drawer label="Knossos">
-                <div class="settings-exp drawer-exp">Basic Knossos settings for downloads, errors, and data</div>
+                <div class="settings-exp drawer-exp">Settings for basic Knossos options, errors, and data</div>
                 <div class="form-group">
                     <label class="col-sm-4 control-label">Data Path:</label>
                     <div class="col-sm-8">
                         <small>{{ knossos.base_path }}</small>
                         <button @click.prevent="changeBasePath">Browse</button>
-                    </div>
-                </div>
-
-                <div class="form-group">
-                    <label class="col-sm-4 control-label">Max Downloads:</label>
-                    <div class="col-sm-8">
-                        <input type="number" style="width: 50px" v-model.number="knossos.max_downloads">
                     </div>
                 </div>
 
@@ -120,6 +113,34 @@ export default {
                             <option value="stable">Stable</option>
                             <option value="rc">RCs</option>
                             <option value="nightly">Nightlies</option>
+                        </select>
+                    </div>
+                </div>
+            </kn-drawer>
+
+            <kn-drawer label="Downloads">
+                <div class="settings-exp drawer-exp">Configuration of how Knossos handles downloads</div>
+                <div class="form-group">
+                    <label class="col-sm-4 control-label">Max Downloads:</label>
+                    <div class="col-sm-8">
+                        <input type="number" style="width: 50px" v-model.number="knossos.max_downloads">
+                    </div>
+                </div>
+
+                <div class="form-group">
+                    <label class="col-sm-4 control-label">Download bandwidth limit:</label>
+                    <div class="col-sm-8">
+                        <select v-model="knossos.download_bandwidth">
+                            <option v-bind:value="-1 ">No limit</option>
+                            <option v-bind:value="128 * 1024">128 KB/s</option>
+                            <option v-bind:value="512 * 1024">512 KB/s</option>
+                            <option v-bind:value="1 * 1024 * 1024">1 MB/s</option>
+                            <option v-bind:value="2 * 1024 * 1024">2 MB/s</option>
+                            <option v-bind:value="3 * 1024 * 1024">3 MB/s</option>
+                            <option v-bind:value="5 * 1024 * 1024">5 MB/s</option>
+                            <option v-bind:value="10 * 1024 * 1024">10 MB/s</option>
+                            <option v-bind:value="20 * 1024 * 1024">20 MB/s</option>
+                            <option v-bind:value="50 * 1024 * 1024">50 MB/s</option>
                         </select>
                     </div>
                 </div>

--- a/knossos/center.py
+++ b/knossos/center.py
@@ -53,6 +53,7 @@ settings = {
     'base_dirs': [],
     'hash_cache': None,
     'max_downloads': 3,
+    'download_bandwidth': -1.0,  # negative numbers are used to specify no limit
     'repos': [('https://fsnebula.org/storage/repo.json', 'FSNebula')],
     'nebula_link': 'https://fsnebula.org/api/1/',
     'update_notify': True,

--- a/knossos/launcher.py
+++ b/knossos/launcher.py
@@ -171,6 +171,8 @@ def run_knossos():
         return
 
     util.DL_POOL.set_capacity(center.settings['max_downloads'])
+    if center.settings['download_bandwidth'] > 0.0:
+        util.SPEED_LIMIT_BUCKET.set_rate(center.settings['download_bandwidth'])
 
     center.app = app
     center.installed = repo.InstalledRepo()

--- a/knossos/settings.py
+++ b/knossos/settings.py
@@ -553,6 +553,9 @@ def save_setting(name, value):
     if name == 'max_downloads':
         if value != center.settings['max_downloads']:
             util.DL_POOL.set_capacity(value)
+    if name == 'download_bandwidth':
+        if value > 0.0:
+            util.SPEED_LIMIT_BUCKET.set_rate(value)
     elif name == 'language':
         # NOTE: This is deliberately not translated.
         QtWidgets.QMessageBox.information(None, 'Knossos', 'Please restart Knossos to complete the language change.')


### PR DESCRIPTION
This uses a token bucket for limiting how fast files are downloaded by
Knossos. The settings GUI could be improved but it should work well for
most use cases and I simply don't have the HTML/JS knowledge to
implement a better speed selection.

I also added a new settings section for downloads since the "Knossos"
section started to get a little big.