### PR TITLE
Check package environment on local mod data loading

### DIFF
--- a/knossos/repo.py
+++ b/knossos/repo.py
@@ -855,7 +855,11 @@ class InstalledMod(Mod):
         self.custom_build = values.get('custom_build', None)
         self.check_notes = values.get('check_notes', '')
         for pkg in pkgs:
-            self.packages.append(InstalledPackage(pkg, self))
+            installed_pkg = InstalledPackage(pkg, self)
+            # If the user installed packages on multiple platforms into the same directory then an installed package
+            # may be present that is not valid for the current environment so we need to check that here
+            if installed_pkg.check_env():
+                self.packages.append(installed_pkg)
 
     def get(self):
         return {


### PR DESCRIPTION
This is needed since both Windows and Linux packages could be installed
at the same time when the user uses the same directory on multiple
platforms.