### PR TITLE
Add mod.ini import support

### DIFF
--- a/html/templates/kn-devel-page.vue
+++ b/html/templates/kn-devel-page.vue
@@ -181,6 +181,26 @@ export default {
             vm.popup_visible = true;
         },
 
+        openImportPopup() {
+            vm.popup_mode = 'import_ini_mod';
+            vm.popup_title = 'Import mod.ini';
+            vm.popup_mod_name = '';
+            vm.popup_mod_id = '';
+            vm.popup_mod_version = '1.0.0';
+            vm.popup_mod_type = 'mod';
+            vm.popup_mod_tcs = this.mods.filter((mod) => mod.type === 'tc');
+            vm.popup_mod_parent = '';
+
+            for(let tc of vm.popup_mod_tcs) {
+                if(tc.id === 'FS2') {
+                    vm.popup_mod_parent = 'FS2';
+                    break;
+                }
+            }
+
+            vm.popup_visible = true;
+        },
+
         openNewVersionPopup() {
             vm.popup_mode = 'new_mod_version';
             vm.popup_title = 'Create a new mod version';
@@ -490,6 +510,7 @@ export default {
     <div>
         <div class="scroll-style mlist">
             <button class="mod-btn btn-link-blue" @click.prevent="openCreatePopup"><span class="btn-text">CREATE</span></button>
+            <button class="mod-btn btn-link-blue" @click.prevent="openImportPopup"><span class="btn-text">IMPORT INI</span></button>
             <!-- <button class="btn btn-default btn-small dev-btn" @click.prevent="showRetailPrompt">INSTALL RETAIL</button> -->
 
             <a href="#" v-for="mod in mods" v-if="mod.dev_mode" :key="mod.id" :class="{ active: selected_mod && selected_mod.id === mod.id }" @click="selectMod(mod)">{{ mod.title }}</a>

--- a/knossos/repo.py
+++ b/knossos/repo.py
@@ -829,11 +829,6 @@ class InstalledMod(Mod):
             mod.folder = os.path.normpath(os.path.dirname(path))
             mod.set(data)
             return mod
-        elif path.lower().endswith('.ini'):
-            mod = IniMod()
-            mod.folder = os.path.normpath(os.path.dirname(path))
-            mod.load(path)
-            return mod
         else:
             return None
 
@@ -1064,7 +1059,7 @@ class IniMod(InstalledMod):
         self._pr_list = []
         self._sc_list = []
 
-        self.version = semantic_version.Version('1.0.0+ini')
+        self.version = semantic_version.Version('1.0.0')
 
     def load(self, path):
         with open(path, 'r') as stream:
@@ -1081,7 +1076,7 @@ class IniMod(InstalledMod):
                     continue
 
                 if name == 'modname':
-                    self.title = value + ' (ini)'
+                    self.title = value
                 elif name == 'infotext':
                     self.description = value
                 elif name.startswith('image'):
@@ -1091,11 +1086,11 @@ class IniMod(InstalledMod):
                 elif name in ('secondarylist', 'secondrylist'):
                     self._sc_list = value.split(',')
 
-        self.folder = os.path.basename(os.path.dirname(path))
+        self.folder = os.path.dirname(path)
         if self.title == '':
-            self.title = self.folder + ' (ini)'
+            self.title = os.path.basename(self.folder)
 
-        self.mid = '##INI_COMPAT#' + self.folder
+        self.mid = os.path.basename(self.folder)
         if self.logo:
             self.logo_path = os.path.join(path, self.logo)
 
@@ -1103,6 +1098,11 @@ class IniMod(InstalledMod):
             'name': 'Content',
             'status': 'required'
         }, self)
+
+        # Set some default values
+        self.screenshots = []
+        self.attachments = []
+
         self.add_pkg(pkg)
 
     def get_mod_flag(self):
@@ -1111,6 +1111,12 @@ class IniMod(InstalledMod):
         mods.extend(self._sc_list)
 
         return mods
+
+    def get_primary_list(self):
+        return self._pr_list
+
+    def get_secondary_list(self):
+        return self._sc_list
 
 
 class InstalledPackage(Package):

--- a/knossos/web.py
+++ b/knossos/web.py
@@ -1142,6 +1142,111 @@ class WebBridge(QtCore.QObject):
     def showDescEditor(self, text):
         windows.DescriptionEditorWindow(text)
 
+    @QtCore.Slot(str, result=str)
+    def parseIniMod(self, path):
+        mod = repo.IniMod()
+        mod.load(path)
+        return json.dumps(mod.get())
+
+    @QtCore.Slot(str, str, str, str, str, str, result=bool)
+    def importIniMod(self, ini_path, name, mid, version, mtype, parent):
+        if parent != 'FS2':
+            parent = self._get_mod(parent)
+
+            if parent == -1:
+                QtWidgets.QMessageBox.critical(None, 'Knossos', self.tr('The selected parent TC is not valid!'))
+                return False
+            else:
+                parent = parent.mid
+
+        mod = repo.InstalledMod({
+            'title': name,
+            'id': mid,
+            'version': version,
+            'type': mtype,
+            'parent': parent,
+            'dev_mode': True
+        })
+        mod.generate_folder()
+
+        if os.path.isdir(mod.folder):
+            # TODO: Check online, too?
+            QtWidgets.QMessageBox.critical(None, 'Knossos', self.tr('There already exists a mod with the chosen ID!'))
+            return False
+
+        upper_folder = os.path.dirname(mod.folder)
+        if not os.path.isdir(upper_folder):
+            logging.error('%s did not exist during mod creation! (parent = %s)' % (mod.folder, mod.parent))
+            QtWidgets.QMessageBox.critical(None, 'Knossos', self.tr('The chosen parent does not exist! Something went very wrong here!!'))
+            return False
+
+        # We need the ini mod for determining where to pull the VPs from
+        ini_mod = repo.IniMod()
+        ini_mod.load(ini_path)
+
+        if len(ini_mod.get_primary_list()) > 0:
+            QtWidgets.QMessageBox.critical(None, 'Knossos', self.tr(
+                'Ini mods with a primary list are currently not supported for importing!'))
+            return False
+
+        # This dict will convert a known secondary list entry to a mod.json style dependency
+        dependency_mapping = {
+            "mediavps_2014": {
+                "id": "MVPS",
+                "version": "3.7.2",
+            },
+            "mediavps_3612": {
+                "id": "MVPS",
+                "version": "3.6.12",
+            },
+            "mediavps": {
+                "id": "MVPS",
+                "version": "3.6.10",
+            },
+        }
+
+        package_dependencies = []
+
+        for dependency in ini_mod.get_secondary_list():
+            dependency = dependency.lower()  # The mapping only works for lower case
+            if dependency not in dependency_mapping:
+                # An unknown dependency is just skipped
+                QtWidgets.QMessageBox.warning(None, 'Knossos',
+                                              self.tr(
+                                                  'The mod.ini dependency %s is not known to Knossos and could not be converted to a mod.json dependency.')
+                                              % (dependency))
+                continue
+
+            package_dependencies.append(dependency_mapping[dependency])
+
+        task = tasks.VpExtractionTask(mod, ini_mod)
+
+        def finish_import():
+            for vp_file in task.get_results():
+                base_filename = os.path.basename(vp_file).replace(".vp", "")
+
+                pkg = repo.InstalledPackage({
+                    'name': base_filename,
+                    'status': 'required',
+                    'folder': base_filename,
+                    'dependencies': package_dependencies,
+                    'is_vp': True
+                })
+                mod.add_pkg(pkg)
+
+            center.installed.add_mod(mod)
+            mod.update_mod_flag()
+
+            mod.save()
+
+            center.main_win.update_mod_list()
+
+        task.done.connect(finish_import)
+
+        tasks.run_task(task)
+
+        return True
+
 
 if QtWebChannel:
     BrowserCtrl = WebBridge


### PR DESCRIPTION
This adds an action to import a legacy mod into the Knossos system which
performs the most annoying steps automatically. This will try to convert
the old style dependency management to the new style by using some
hard-coded conversion values. Currently, that table only contains the
various MediaVP versions.

This will also extract the individual VPs and create packages for each
of them. That is currently done on the main thread which means that the
GUI is blocked while the VPs are being extracted. I don't know how the
task system of Knossos works yet so I chose to implement the basic
version first.