### PR TITLE
Do not display mod version on the mod tile

### DIFF
--- a/html/templates/kn-mod-explore.vue
+++ b/html/templates/kn-mod-explore.vue
@@ -97,7 +97,7 @@ export default {
                 </div>
             </div>
             <div class="mod-progress"><div class="bar" :style="'width: ' + mod.progress + '%'"></div></div>
-            <div class="mod-title"><p>{{ mod.title }} {{ mod.version }}</p></div>
+            <div class="mod-title"><p>{{ mod.title }}</p></div>
         </div>
     </div>
 </template>

--- a/html/templates/kn-mod-home.vue
+++ b/html/templates/kn-mod-home.vue
@@ -104,7 +104,7 @@ export default {
                 </div>
             </div>
             <div class="mod-progress"><div class="bar" :style="'width: ' + mod.progress + '%'"></div></div>
-            <div class="mod-title"><p>{{ mod.title }} {{ mod.version }}</p></div>
+            <div class="mod-title"><p>{{ mod.title }}</p></div>
         </div>
     </div>
 </template>


### PR DESCRIPTION
The mod version on the individual tiles do not serve any purpose and can
be misleading so I removed it.