### PR TITLE
Add flag parsing using the new JSON format

### DIFF
--- a/knossos/web.py
+++ b/knossos/web.py
@@ -430,9 +430,6 @@ class WebBridge(QtCore.QObject):
         if center.settings['fs2_bin']:
             try:
                 flags = settings.get_fso_flags(center.settings['fs2_bin'])
-
-                if flags:
-                    flags = flags.to_dict()
             except Exception:
                 logging.exception('Failed to fetch FSO flags!')
 
@@ -1095,8 +1092,6 @@ class WebBridge(QtCore.QObject):
         flags = None
         if mid == 'custom':
             flags = settings.get_fso_flags(version)
-            if flags:
-                flags = flags.to_dict()
 
             return json.dumps(flags)
 
@@ -1107,9 +1102,6 @@ class WebBridge(QtCore.QObject):
             for exe in mod.get_executables():
                 if not exe['label']:
                     flags = settings.get_fso_flags(exe['file'])
-
-            if flags:
-                flags = flags.to_dict()
         except repo.NoExecutablesFound:
             return 'null'
         except Exception:


### PR DESCRIPTION
I encountered an issue with the environment that the executable is
started with. If it only contained the LD_LIBRARY_PATH entry then the
SDL code within FSO didn't work for some reason. If the env parameter
was omitted then it worked properly so I emulated the default value by
copying the existing process environment and then change that in case
any changes are needed at all. This fixed the issue on my system.

This does not use the device enumeration features of the new format yet.