### PR TITLE
Fix fs2_open.ini file format

### DIFF
--- a/knossos/settings.py
+++ b/knossos/settings.py
@@ -447,7 +447,7 @@ def write_fso_config(sections):
             stream.write('[%s]\n' % name)
 
             for k, v in pairs.items():
-                stream.write('%s = %s\n' % (k, v))
+                stream.write('%s=%s\n' % (k, v))
 
             stream.write('\n')
 


### PR DESCRIPTION
The current format (with spaces around the `=`) breaks the INI parser of
FSO since that code is pretty stupid. This should fix the configuration
issues I encountered when I tried to use Knossos.