### PR TITLE
Fix libffi crash when calling SDL_JoystickGetGUIDString

### DIFF
--- a/knossos/clibs.py
+++ b/knossos/clibs.py
@@ -57,7 +57,8 @@ class SDL_DisplayMode(ctypes.Structure):
 
 class SDL_JoystickGUID(ctypes.Structure):
     _fields_ = [
-        ('data', ctypes.c_uint8 * 16)
+        ('data1', ctypes.c_uint8 * 8),
+        ('data2', ctypes.c_uint8 * 8)
     ]
 
 


### PR DESCRIPTION
It appears like there is a known issue with passing a 16-byte array by
value to a C-function: https://bugs.python.org/issue22273

I fixed that by simply splitting the array into two smaller arrays which
fixed the error for me. SDL still returns the correct values so it seems
like it works for the C-code.