### PR TITLE
Skip the cmdline_fso.cfg writing when launching FSO

### DIFF
--- a/knossos/runner.py
+++ b/knossos/runner.py
@@ -14,20 +14,21 @@
 
 from __future__ import absolute_import, print_function
 
-import sys
-import os
-import logging
-import re
-import threading
-import subprocess
-import time
 import ctypes.util
-import stat
 import json
+import logging
+import os
+import re
 import shlex
+import stat
+import subprocess
+import sys
+import threading
+import time
 from subprocess import CalledProcessError
 
 from . import uhf
+
 uhf(__name__)
 from . import center, repo, util, settings
 from .qt import QtCore, QtWidgets, run_in_qt
@@ -115,9 +116,10 @@ class Fs2Watcher(threading.Thread):
 
     def prepare_fso_config(self, fs2_bin):
         cfg = settings.get_settings()
+        settings.save_fso_settings(cfg['fso'])
+
         if not cfg['fso']['joystick_guid']:
             # No joystick selected
-            settings.ensure_fso_config()
             return True
 
         sel_guid = cfg['fso']['joystick_guid']
@@ -456,10 +458,8 @@ def run_mod(mod, tool=None, exe_label=None):
 
 def run_mod_ex(mod, binpath, mod_flag):
     # Put the cmdline together
-    cmdline = mod.cmdline
-
     if mod.user_cmdline:
-        cmdline = mod.user_cmdline
+        cmdline = shlex.split(mod.user_cmdline)
     else:
         cmdline = apply_global_flags(mod)
 
@@ -493,28 +493,14 @@ def run_mod_ex(mod, binpath, mod_flag):
         # The paths for -mod must be relative to the base path.
         # TODO: Do we have to make sure that there are no special characters here or are the rules for mod.folder and
         #       pkg.folder enough to assure that?
-        cmdline += ' -mod ' + ','.join([os.path.relpath(p, basepath) for p in mod_flag])
+        cmdline.append('-mod')
+        cmdline.append(','.join([os.path.relpath(p, basepath) for p in mod_flag]))
 
-    # Look for the cmdline path.
-    path = os.path.join(settings.get_fso_profile_path(), 'data/cmdline_fso.cfg')
+    # We put all arguments in the command line so we can skip the config file
+    cmdline.append('-parse_cmdline_only')
 
-    # Create the containing folders if they are missing.
-    if not os.path.isfile(path):
-        basep = os.path.dirname(path)
-        if not os.path.isdir(basep):
-            os.makedirs(basep)
-
-    try:
-        with open(path, 'w') as stream:
-            stream.write(cmdline)
-    except Exception:
-        logging.exception('Failed to modify "%s". Not starting!!', path)
-
-        QtWidgets.QMessageBox.critical(None, translate('runner', 'Error'),
-            translate('runner', 'Failed to edit "%s"! I can\'t change the current mod!') % path)
-    else:
-        logging.info('Starting mod "%s" with cmdline "%s" and tool "%s".', mod.title, cmdline, binpath)
-        Fs2Watcher([binpath], cwd=basepath)
+    logging.info('Starting mod "%s" with cmdline "%s" and tool "%s".', mod.title, cmdline, binpath)
+    Fs2Watcher([binpath] + cmdline, cwd=basepath)
 
 
 def stringify_cmdline(line):
@@ -559,11 +545,11 @@ def apply_global_flags(mod):
     flag_states = get_global_flags(mod)
     if not flag_states:
         # No global flags set
-        return mod.cmdline
+        return shlex.split(mod.cmdline)
 
-    custom_flags = ''
+    custom_flags = []
     if '#custom' in flag_states:
-        custom_flags = ' ' + flag_states['#custom']
+        custom_flags = shlex.split(flag_states['#custom'])
 
     cmdline = shlex.split(mod.cmdline)
     for flag, state in flag_states.items():
@@ -579,4 +565,4 @@ def apply_global_flags(mod):
             if flag not in cmdline:
                 cmdline.append(flag)
 
-    return ' '.join([shlex.quote(p) for p in cmdline]) + custom_flags
+    return [shlex.quote(p) for p in cmdline] + custom_flags

--- a/knossos/web.py
+++ b/knossos/web.py
@@ -1617,7 +1617,7 @@ class WebBridge(QtCore.QObject):
             return ''
 
         try:
-            return runner.apply_global_flags(mod)
+            return ' '.join(runner.apply_global_flags(mod))
         except repo.NoExecutablesFound:
             return ''
 


### PR DESCRIPTION
The original reason why that file was used was to allow users to
directly launch FSO from the file manager. Since that doesn't work
anyway in Knossos there is no reason to keep writing that file.

This is a minor change which makes it easier to use Knossos when
starting FSO using different launchers.

I added a save_fso_settings call before launching FSO to make sure that
the config file is updated before FSO is launched. This will make sure
that the engine uses the correct settings path.

Also, I updated `.gitignore` to include the files generated by PLY since they
always showed up as "changed" for me. Since the files are generated anyway
it doesn't matter if they are under VCS or not.