### PR TITLE
Hide FS2 mods when retail is not installed

### DIFF
--- a/html/templates/kn-settings-page.vue
+++ b/html/templates/kn-settings-page.vue
@@ -77,7 +77,7 @@ export default {
                 fs2mod.setBasePath(this.knossos.base_path);
             }
 
-            for(let set of ['max_downloads', 'use_raven', 'engine_stability', 'download_bandwidth', 'update_notify', 'custom_bar']) {
+            for(let set of ['max_downloads', 'use_raven', 'engine_stability', 'download_bandwidth', 'update_notify', 'custom_bar', 'show_fs2_mods_without_retail']) {
                 if(this.knossos[set] != this.old_settings.knossos[set]) {
                     fs2mod.saveSetting(set, JSON.stringify(this.knossos[set]));
                 }
@@ -123,7 +123,7 @@ export default {
         <div class="col-sm-6">
             <h2>
                 Settings
-                <button class="mod-btn btn-blue pull-right" @click="showRetailPrompt" v-if="!retail_installed">Install Retail</button>
+                <button class="mod-btn btn-blue pull-right" @click="showRetailPrompt" v-if="!retail_installed">Install FS2</button>
                 <button class="mod-btn btn-green pull-right" @click="save" v-if="!loading">Save</button>
                 <button class="mod-btn btn-grey pull-right" disabled v-if="loading">Loading...</button>
             </h2>
@@ -168,6 +168,13 @@ export default {
                     <label class="col-sm-4 control-label">Custom Title Bar:</label>
                     <div class="col-sm-8">
                         <input type="checkbox" v-model="knossos.custom_bar">
+                    </div>
+                </div>
+
+                <div class="form-group" v-if="!retail_installed">
+                    <label class="col-sm-4 control-label">Show FreeSpace 2 Mods:</label>
+                    <div class="col-sm-8">
+                        <input type="checkbox" v-model="knossos.show_fs2_mods_without_retail">
                     </div>
                 </div>
             </kn-drawer>

--- a/knossos/center.py
+++ b/knossos/center.py
@@ -70,7 +70,8 @@ settings = {
     'joystick': {
         'guid': None,
         'id': 99999
-    }
+    },
+    'show_fs2_mods_without_retail': False
 }
 
 if sys.platform.startswith('win'):

--- a/knossos/settings.py
+++ b/knossos/settings.py
@@ -684,9 +684,16 @@ def save_setting(name, value):
         else:
             center.main_win.hide_bar()
 
+    refresh_mod_list = False
+    if name == 'show_fs2_mods_without_retail':
+        if value != center.settings['show_fs2_mods_without_retail']:
+            refresh_mod_list = True
+
     center.settings[name] = value
     center.save_settings()
-
+    
+    if refresh_mod_list:
+        center.main_win.update_mod_list()
 
 def get_fso_log(self):
     logpath = os.path.join(get_fso_profile_path(), 'data/fs2_open.log')

--- a/knossos/windows.py
+++ b/knossos/windows.py
@@ -363,11 +363,13 @@ class HellWindow(Window):
 
     def search_mods(self):
         mods = None
+        omit_fs2_mods = False
 
         if self._mod_filter in ('home', 'develop'):
             mods = center.installed.mods
         elif self._mod_filter == 'explore':
             mods = center.mods.mods
+            omit_fs2_mods = not center.installed.has('FS2') and not center.settings['show_fs2_mods_without_retail']
         else:
             mods = {}
 
@@ -377,6 +379,8 @@ class HellWindow(Window):
         for mid, mvs in mods.items():
             if query in mvs[0].title.lower():
                 mod = mvs[0]
+                if mod.parent == 'FS2' and omit_fs2_mods:
+                    continue
                 if mod.mtype == 'engine' and self._mod_filter != 'develop':
                     mvs = [mv for mv in mvs if mv.satisfies_stability(center.settings['engine_stability'])]
                     if len(mvs) == 0:


### PR DESCRIPTION
Also add a settings option (default value false) for showing FS2 mods even when retail is not installed.

We still need to indicate when retail is not installed that a mod is an FS2 mod and requires retail to play, but that's out of scope for this PR.