### PR TITLE
Revise post-setup retail install prompt

### DIFF
--- a/html/js/main.js
+++ b/html/js/main.js
@@ -92,7 +92,7 @@ function init() {
         vm.page = 'details';
     });
     fs2mod.showRetailPrompt.connect(() => {
-        vm.showRetailPrompt();
+        vm.showRetailPrompt(true);
     });
     fs2mod.showLaunchPopup.connect((info) => {
         info = JSON.parse(info);

--- a/html/templates/kn-devel-page.vue
+++ b/html/templates/kn-devel-page.vue
@@ -112,7 +112,7 @@ export default {
 
     methods: {
         showRetailPrompt() {
-            vm.showRetailPrompt();
+            vm.showRetailPrompt(false);
         },
 
         openModFolder() {
@@ -553,7 +553,7 @@ export default {
     <div>
         <div class="scroll-style mlist">
             <button class="mod-btn btn-link-blue" @click.prevent="openCreatePopup"><span class="btn-text">CREATE</span></button>
-            <!-- <button class="btn btn-default btn-small dev-btn" @click.prevent="showRetailPrompt">INSTALL RETAIL</button> -->
+            <!-- <button class="btn btn-default btn-small dev-btn" @click.prevent="showRetailPrompt">INSTALL FS2</button> -->
 
             <a href="#" v-for="mod in mods" v-if="mod.dev_mode" :key="mod.id" :class="{ active: selected_mod && selected_mod.id === mod.id }" @click="selectMod(mod)">{{ mod.title }}</a>
         </div>

--- a/html/templates/kn-page.vue
+++ b/html/templates/kn-page.vue
@@ -475,11 +475,11 @@ export default {
                     </form>
                     <p v-if="retail_install_option === 'select-installation-folder'">
                         Select the folder that has the FreeSpace 2 data files. The folder should include the file <strong>Root_fs2.vp</strong>.<br>
-                        Knossos will copy the files into the Knossos folder.
+                        Knossos will copy the files into the Knossos library.
                     </p>
                     <p v-else-if="retail_install_option === 'select-installer-file'">
                         Select the GOG FreeSpace 2 installer (example: setup_freespace2_2.0.0.8.exe).<br>
-                        Knossos will extract the data files from the installer.
+                        Knossos will extract the data files from the installer into the Knossos library.
                     </p>
                     <p v-else>
                         <span v-if="retail_searching"><strong>Searching files...</strong></span>

--- a/html/templates/kn-page.vue
+++ b/html/templates/kn-page.vue
@@ -495,7 +495,7 @@ export default {
                         <div class="input-group" :style="{ visibility: (retail_install_option !== 'auto-detect-installation') ? 'visible' : 'hidden' }">
                             <input type="text" class="form-control" v-model="retail_data_path">
                             <span class="input-group-btn">
-                                <button class="btn btn-default inline-button" @click.prevent="selectRetailLocation">Browse...</button>
+                                <button class="btn btn-default" @click.prevent="selectRetailLocation">Browse...</button>
                             </span>
                         </div>
                     </p>

--- a/html/templates/kn-page.vue
+++ b/html/templates/kn-page.vue
@@ -463,12 +463,10 @@ export default {
                                 <input type="radio" value="auto-detect-installation" v-model="retail_install_option" @change="retailAutoDetect">
                                 Auto-detect installation
                             </label>
-                            <br>
-                            <labe class="checkbox">
+                            <label class="checkbox">
                                 <input type="radio" value="select-installation-folder" v-model="retail_install_option" @change="retail_data_path = ''">
                                 Select installation folder
-                            </labe>
-                            <br>
+                            </label>
                             <label class="checkbox">
                                 <input type="radio" value="select-installer-file" v-model="retail_install_option" @change="retail_data_path = ''">
                                 Select GOG installer file

--- a/html/templates/kn-page.vue
+++ b/html/templates/kn-page.vue
@@ -282,7 +282,7 @@ export default {
             call(fs2mod.copyRetailData, this.retail_data_path, (result) => {
                 if (result) {
                     this.popup_visible = false;
-                    // TODO emit/generate event to trigger update on settings page
+                    this.$emit('retail-install-status-changed');
                 }
             });
 

--- a/html/templates/kn-page.vue
+++ b/html/templates/kn-page.vue
@@ -453,7 +453,9 @@ export default {
                 <div v-if="popup_mode === 'retail_prompt'">
                     <p>
                         <span v-if="mod_install_attempted">You need the FreeSpace 2 data files to play this mod.<br></span>
-                        Choose how you want to install FreeSpace 2.
+                        Choose how you want to install FreeSpace 2. You can buy it from
+                        <a href="https://www.gog.com/game/freespace_2" class="open-ext">GOG</a>
+                        or <a href="https://store.steampowered.com/app/273620/Freespace_2/" class="open-ext">Steam</a>.
                     </p>
                     <form class="form-horizontal col-xs-12">
                         <div class="form-group">

--- a/html/templates/kn-page.vue
+++ b/html/templates/kn-page.vue
@@ -68,8 +68,7 @@ export default {
         retail_found: false,
         retail_data_path: '',
         mod_install_attempted: false,
-        retail_install_option: 'auto-detect-installation',
-        retail_install_completed: false
+        retail_install_option: 'auto-detect-installation'
     }),
 
     watch: {
@@ -280,14 +279,12 @@ export default {
         },
 
         finishRetailPrompt() {
-            if(this.retail_data_path) {
-                call(fs2mod.copyRetailData, this.retail_data_path, (result) => {
-                    if (result) {
-                        this.popup_visible = false;
-                        this.retail_install_completed = true;
-                    }
-                });
-            }
+            call(fs2mod.copyRetailData, this.retail_data_path, (result) => {
+                if (result) {
+                    this.popup_visible = false;
+                    // TODO emit/generate event to trigger update on settings page
+                }
+            });
 
         },
 
@@ -394,7 +391,7 @@ export default {
 
         <kn-scroll-container v-if="page === 'settings'" key="settings" :dummy="mods">
             <div class="info-page settings-page container-fluid">
-                <kn-settings-page :mods="mods" :retail-install-completed="retail_install_completed"></kn-settings-page>
+                <kn-settings-page :mods="mods"></kn-settings-page>
             </div>
         </kn-scroll-container>
 
@@ -460,14 +457,20 @@ export default {
                     </p>
                     <form class="form-horizontal col-xs-12">
                         <div class="form-group">
-                            <input type="radio" id="auto-detect-installation" value="auto-detect-installation" v-model="retail_install_option" @click="retailAutoDetect">
-                            <label for="auto-detect-installation">Auto-detect installation</label>
+                            <label class="checkbox">
+                                <input type="radio" value="auto-detect-installation" v-model="retail_install_option" @change="retailAutoDetect">
+                                Auto-detect installation
+                            </label>
                             <br>
-                            <input type="radio" id="select-installation-folder" value="select-installation-folder" v-model="retail_install_option" @click="retail_data_path = ''">
-                            <label for="select-installation-folder">Select installation folder</label>
+                            <labe class="checkbox">
+                                <input type="radio" value="select-installation-folder" v-model="retail_install_option" @change="retail_data_path = ''">
+                                Select installation folder
+                            </labe>
                             <br>
-                            <input type="radio" id="select-installer-file" value="select-installer-file" v-model="retail_install_option" @click="retail_data_path = ''">
-                            <label for="select-installer-file">Select GOG installer file</label>
+                            <label class="checkbox">
+                                <input type="radio" value="select-installer-file" v-model="retail_install_option" @change="retail_data_path = ''">
+                                Select GOG installer file
+                            </label>
                         </div>
                     </form>
                     <p v-if="retail_install_option === 'select-installation-folder'">
@@ -490,7 +493,7 @@ export default {
                     </p>
                     <p>
                         <div class="input-group" :style="{ visibility: (retail_install_option !== 'auto-detect-installation') ? 'visible' : 'hidden' }">
-                            <input type="text" class="form-control" v-model="retail_data_path" :disabled="retail_searching">
+                            <input type="text" class="form-control" v-model="retail_data_path">
                             <span class="input-group-btn">
                                 <button class="btn btn-default inline-button" @click.prevent="selectRetailLocation">Browse...</button>
                             </span>

--- a/html/templates/kn-settings-page.vue
+++ b/html/templates/kn-settings-page.vue
@@ -114,12 +114,18 @@ export default {
 
         showRetailPrompt() {
             vm.showRetailPrompt(false);
+        },
+
+        updateRetailInstalled() {
+            call(fs2mod.getRetailInstallStatus, (status) => {
+                this.retail_installed = status;
+            });
         }
     }
 };
 </script>
 <template>
-    <div class="row form-horizontal settings-container">
+    <div class="row form-horizontal settings-container" @retail-install-status-changed="updateRetailInstalled">
         <div class="col-sm-6">
             <h2>
                 Settings

--- a/html/templates/kn-settings-page.vue
+++ b/html/templates/kn-settings-page.vue
@@ -7,7 +7,7 @@
  */
 
 export default {
-    props: ['mods'],
+    props: ['mods', 'retailInstallCompleted'],
 
     data: () => ({
         loading: false,
@@ -113,7 +113,7 @@ export default {
         },
 
         showRetailPrompt() {
-            vm.showRetailPrompt();
+            vm.showRetailPrompt(false);
         }
     }
 };

--- a/html/templates/kn-settings-page.vue
+++ b/html/templates/kn-settings-page.vue
@@ -7,7 +7,7 @@
  */
 
 export default {
-    props: ['mods', 'retailInstallCompleted'],
+    props: ['mods'],
 
     data: () => ({
         loading: false,

--- a/html/templates/kn-settings-page.vue
+++ b/html/templates/kn-settings-page.vue
@@ -58,7 +58,7 @@ export default {
 
     methods: {
         changeBasePath() {
-            call(fs2mod.browseFolder, 'Please select a folder', this.knossos.base_path || '', (path) => {
+            call(fs2mod.browseFolder, 'Select a folder for the Knossos library', this.knossos.base_path || '', (path) => {
                 if(path) this.knossos.base_path = path;
             });
         },
@@ -132,7 +132,7 @@ export default {
             <kn-drawer label="Knossos">
                 <div class="settings-exp drawer-exp">Settings for basic Knossos options, errors, and data</div>
                 <div class="form-group">
-                    <label class="col-sm-4 control-label">Data Path:</label>
+                    <label class="col-sm-4 control-label">Library Path:</label>
                     <div class="col-sm-8">
                         <small>{{ knossos.base_path }}</small>
                         <button class="mod-btn btn-link-grey pull-right" @click.prevent="changeBasePath">Browse</button>

--- a/html/templates/kn-settings-page.vue
+++ b/html/templates/kn-settings-page.vue
@@ -114,18 +114,12 @@ export default {
 
         showRetailPrompt() {
             vm.showRetailPrompt(false);
-        },
-
-        updateRetailInstalled() {
-            call(fs2mod.getRetailInstallStatus, (status) => {
-                this.retail_installed = status;
-            });
         }
     }
 };
 </script>
 <template>
-    <div class="row form-horizontal settings-container" @retail-install-status-changed="updateRetailInstalled">
+    <div class="row form-horizontal settings-container">
         <div class="col-sm-6">
             <h2>
                 Settings

--- a/html/templates/kn-welcome-page.vue
+++ b/html/templates/kn-welcome-page.vue
@@ -7,7 +7,6 @@ export default {
         retail_searching: false,
         retail_found: false,
         retail_path: '',
-        root_vp_path: '',
         retail_installed: false,
 
         installer_path: '',
@@ -65,15 +64,14 @@ export default {
             });
         },
 
-        selectRetailRootVP() {
-            call(fs2mod.browseFiles, 'Select your FreeSpace 2 folder\'s Root_fs2.vp', this.root_vp_path, '*.vp', (vp_files) => {
-                if (vp_files.length > 0) {
-                    this.root_vp_path = vp_files[0];
-                    call(fs2mod.verifyRootVPFolder, this.root_vp_path, (retail_path) => {
-                        if(retail_path) {
-                            this.retail_path = retail_path;
-                        } else {
-                            this.root_vp_path = '';
+        selectRetailFolder() {
+            call(fs2mod.browseFiles, 'Select your FreeSpace 2 folder\'s Root_fs2.vp', '', '*.vp', (vp_files) => {
+                if(vp_files.length > 0) {
+                    let root_vp_path = vp_files[0];
+
+                    call(fs2mod.verifyRootVPFolder, root_vp_path, (result) => {
+                        if(result) {
+                            this.retail_path = result;
                         }
                     });
                 }
@@ -194,9 +192,9 @@ export default {
                     </p>
 
                     <div class="input-group">
-                        <input type="text" class="form-control" v-model="root_vp_path">
+                        <input type="text" class="form-control" v-model="retail_path">
                         <span class="input-group-btn">
-                            <button class="btn btn-default" @click.prevent="selectRetailRootVP">Browse...</button>
+                            <button class="btn btn-default" @click.prevent="selectRetailFolder">Browse...</button>
                             <button class="btn btn-primary" @click.prevent="processRetail(true)">Continue</button>
                         </span>
                     </div>

--- a/knossos/web.py
+++ b/knossos/web.py
@@ -1816,9 +1816,6 @@ class WebBridge(QtCore.QObject):
                                           '<a href="https://www.hard-light.net/forums/index.php?topic=94068.0">'
                                           'Knossos release thread</a> on the Hard Light Productions forums.')
 
-    @QtCore.Slot(result=bool)
-    def getRetailInstallStatus(self):
-        return center.installed.has('FS2')
 
 if QtWebChannel:
     BrowserCtrl = WebBridge

--- a/knossos/web.py
+++ b/knossos/web.py
@@ -1816,6 +1816,10 @@ class WebBridge(QtCore.QObject):
                                           '<a href="https://www.hard-light.net/forums/index.php?topic=94068.0">'
                                           'Knossos release thread</a> on the Hard Light Productions forums.')
 
+    @QtCore.Slot(result=bool)
+    def getRetailInstallStatus(self):
+        return center.installed.has('FS2')
+
 if QtWebChannel:
     BrowserCtrl = WebBridge
 else:

--- a/knossos/windows.py
+++ b/knossos/windows.py
@@ -363,13 +363,11 @@ class HellWindow(Window):
 
     def search_mods(self):
         mods = None
-        omit_fs2_mods = False
 
         if self._mod_filter in ('home', 'develop'):
             mods = center.installed.mods
         elif self._mod_filter == 'explore':
             mods = center.mods.mods
-            omit_fs2_mods = not center.installed.has('FS2') and not center.settings['show_fs2_mods_without_retail']
         else:
             mods = {}
 


### PR DESCRIPTION
Improve UX of the post-setup retail install process.

P.S. I think I'm getting the hang of this! 😁

P.P.S. Although I added the `inline-button` class to the Browse... button which is from my "revise welcome page" PR #145 . I also couldn't get the `inline-button` class to work when I tried to adapt something from the other PR, presumably something to do with some other CSS rules overriding it, but I don't know what 😠 