### PR TITLE
Revise Develop(ment) tab

### DIFF
--- a/html/css/style.css
+++ b/html/css/style.css
@@ -48,11 +48,18 @@ iframe {
 }
 
 .dev-instructions {
-    margin:0 auto;
-    margin-top: 10%;
-    width: 80%;
-    text-align: center;
+    margin: 0 auto;
+    margin-top: 20%;
+    width: 55%;
+    /* TODO figure out how to center teh div */
+    font-size: 1.25em;
     color: grey;
+}
+
+.dev-instructions p {
+    margin-top: 30px;
+     text-align: center;
+     /*font-size: 1.1em;*/
 }
 
 /* -------------------------- Settings for top bar elements ----------------------------------*/

--- a/html/css/style.css
+++ b/html/css/style.css
@@ -48,18 +48,8 @@ iframe {
 }
 
 .dev-instructions {
-    margin: 0 auto;
-    margin-top: 20%;
-    width: 55%;
-    /* TODO figure out how to center teh div */
-    font-size: 1.25em;
-    color: grey;
-}
-
-.dev-instructions p {
-    margin-top: 30px;
-     text-align: center;
-     /*font-size: 1.1em;*/
+    margin-top: 3%;
+    margin-left: 3%;
 }
 
 /* -------------------------- Settings for top bar elements ----------------------------------*/

--- a/html/templates/kn-devel-page.vue
+++ b/html/templates/kn-devel-page.vue
@@ -604,19 +604,28 @@ export default {
                 <a :href="'https://fsnebula.org/mod/' + encodeURIComponent(selected_mod.id)" class="open-ext">Download Link</a>
             </div>
             <div class="dev-instructions" v-else>
-                <!-- TODO realign this block to upper-left. Centering looks bad. -->
-                Here you can
+                <p>
+                    This tab has advanced features that can help you get started
+                    with FreeSpace Open modding.
+                </p>
+                <p>
+                    Here you can
+                </p>
                 <ul>
                     <li>create new mods</li>
                     <li>edit installed mods</li>
                     <li>apply experimental mod settings</li>
-                    <li>work with the mission editor (FRED)</li>
                     <li>customize a mod's command line options (flags)</li>
                 </ul>
                 <p>
-                    This tab is both an "advanced" section and also a great place<br>
-                    to get started with FreeSpace Open modding.
-                </p>                 
+                    Players on Windows can also work with the mission editor FRED.
+                    <!-- TODO Include a link somewehre "for more information about FRED" to FS Wiki or FREDdocs or something. -->
+                </p>
+                <p>
+                     A version of FRED for all platforms called qtFRED is under development.
+                    <a href="https://www.hard-light.net/forums/index.php?topic=94565.0" class="open-ext">This forum thread</a> tracks its progress.
+                </p>
+                <!-- TODO including a few carefully chosen links to online modding resources might be a good use of space. -->
             </div>
             <div class="form-box" v-if="selected_mod">
                 <div class="tabcorner"></div>

--- a/html/templates/kn-devel-page.vue
+++ b/html/templates/kn-devel-page.vue
@@ -618,7 +618,7 @@ export default {
                     <li>customize a mod's command line options (flags)</li>
                 </ul>
                 <p>
-                    Players on Windows can also work with the mission editor FRED.
+                    Players on Windows can also make missions with the mission editor FRED.
                 </p>
                 <p>
                      A version of FRED for all platforms called qtFRED is available, but it's not yet as full-featured as FRED.<br>
@@ -679,7 +679,7 @@ export default {
                                 repository.
                             </p>
                             <p>
-                                To create a package, click the "Modify Mod" tab on the left and then click the "+ Package" button.<br>
+                                To create a package, click the "+ Package" button on the left.<br>
                                 To edit a packge, click on the package name in the top tab list.
                             </p>
                         </div>
@@ -745,7 +745,7 @@ export default {
 
                                     <span class="help-block" v-if="selected_mod.type === 'tc'">
                                         A standalone game that doesn't depend on other mods and doesn't use FS2 files.<br>
-                                        <strong>Mods for TCs should use the "Mod" type.</strong>
+                                        Mods for TCs should use the "Mod" type.
                                     </span>
 
                                     <span class="help-block" v-if="selected_mod.type === 'engine'">
@@ -753,7 +753,7 @@ export default {
                                     </span>
                                     <!-- TODO uncomment once tools and extensions are supported
                                     <span class="help-block" v-if="selected_mod.type === 'tool'">
-                                        Software other than the FreeSpace Open (FSO) engine
+                                        Software other than the FreeSpace Open (FSO) engine.<br>
                                         Examples include FRED (mission editor) and PCS2 (model converter).
                                     </span>
 
@@ -779,7 +779,7 @@ export default {
                                     <button class="btn btn-small btn-default" @click.prevent="openDescEditor">Open Editor</button>
 
                                     <p class="help-block">
-                                        Use BBCode here. To preview your description, save, go to the Home tab,
+                                        Use <a href="https://en.wikipedia.org/wiki/BBCode" class="open-ext">BBCode</a> here. To preview your description, save, go to the Home tab,
                                         and go to this mod's Details page.
                                     </p>
                                 </div>

--- a/html/templates/kn-devel-page.vue
+++ b/html/templates/kn-devel-page.vue
@@ -578,6 +578,7 @@ export default {
                         <br>
                     </div>
 
+                    <!-- TODO for any button that brings up a dialog, add the "..." -->
                     <div class="buttonpane" v-if="mod_box_tab === 'modify'">
                         <button @click.prevent="reopenUploadPopup" class="mod-btn btn-link-blue" v-if="(this.mod_map[(this.selected_mod || {}).id] || {}).progress">Uploading...</button>
                         <button @click.prevent="uploadMod" class="mod-btn btn-link-blue" v-else>Upload</button><br>
@@ -603,7 +604,19 @@ export default {
                 <a :href="'https://fsnebula.org/mod/' + encodeURIComponent(selected_mod.id)" class="open-ext">Download Link</a>
             </div>
             <div class="dev-instructions" v-else>
-                This is the Development tab. Here you can create new mods or edit currently installed mods. This is also where you can apply experimental mod settings, work with the Freespace Mission Editor, and alter the mod flags and commandline options. <br><br>Consider this an advanced section of Knossos but also a great place to get started if you wish to learn the ins and outs of modding with Freespace 2 Open.
+                <!-- TODO realign this block to upper-left. Centering looks bad. -->
+                Here you can
+                <ul>
+                    <li>create new mods</li>
+                    <li>edit installed mods</li>
+                    <li>apply experimental mod settings</li>
+                    <li>work with the mission editor (FRED)</li>
+                    <li>customize a mod's command line options (flags)</li>
+                </ul>
+                <p>
+                    This tab is both an "advanced" section and also a great place<br>
+                    to get started with FreeSpace Open modding.
+                </p>                 
             </div>
             <div class="form-box" v-if="selected_mod">
                 <div class="tabcorner"></div>
@@ -705,29 +718,30 @@ export default {
                                     </select>
 
                                     <span class="help-block" v-if="selected_mod.type === 'mod'">
-                                        This type is the default and covers most cases. Normally you'll want to use this type.
+                                        (Default) A campaign based either on FreeSpace 2 (retail) or on a total conversion (TC)<br>
                                     </span>
 
                                     <span class="help-block" v-if="selected_mod.type === 'tc'">
-                                        Use this type if your mod doesn't depend on other mods or retail files.<br>
-                                        (Mods for TCs should still use the "Mod" type.)
+                                        A standalone game that doesn't depend on other mods and doesn't use FS2 files<br>
+                                        Mods for TCs should still use the "Mod" type.
                                     </span>
 
                                     <span class="help-block" v-if="selected_mod.type === 'engine'">
-                                        This should only be used for builds FSO builds (fs2_open*.exe, fs2_open*.AppImage, etc.).
+                                        A build of the FreeSpace 2 Open (FSO) engine (fs2_open*.exe, fs2_open*.app, etc.)
                                     </span>
 
                                     <span class="help-block" v-if="selected_mod.type === 'tool'">
-                                        This is used for all executables which aren't FSO like FRED or PCS2.
+                                        Software other than the FreeSpace 2 Open (FSO) engine
+                                        Examples include FRED (mission editor) and PCS2 (model converter).
                                     </span>
 
                                     <span class="help-block" v-if="selected_mod.type === 'ext'">
-                                        This mod type is meant for overrides like custom HUD tables.
+                                        A change that overrides, such as custom HUD tables
                                     </span>
                                 </div>
                             </div>
 
-                            <div class="form-group" v-if="selected_mod.type === 'mod' || selected_mod.type === 'ext'">
+                            <div class="form-group" :style="{visibility: (selected_mod.type === 'mod' || selected_mod.type === 'ext') ? 'visible' : 'hidden'}">
                                 <label class="col-xs-3 control-label">Parent mod</label>
                                 <div class="col-xs-9">
                                     <p class="form-control-static">{{ selected_mod.parent }}</p>
@@ -742,8 +756,8 @@ export default {
                                     <button class="btn btn-small btn-default" @click.prevent="openDescEditor">Open Editor</button>
 
                                     <p class="help-block">
-                                        Please use BBCode here. To preview your description, save, go to your home tab
-                                        and go to this mod's detail page.
+                                        Use BBCode here. To preview your description, save, go to the Home tab,
+                                        and go to this mod's Details page.
                                     </p>
                                 </div>
                             </div>
@@ -768,8 +782,9 @@ export default {
                                     <img :src="'file://' + selected_mod.logo" v-if="selected_mod.logo"><br>
 
                                     <p class="help-block">
-                                        This image should be about 255&times;112 pixels large. Please only use this for legacy logos and mod images from mods predating the Knossos installer.
-                                        If you create a new mod logo or image, please use the above setting.
+                                        This image should be about 255&times;112 pixels large.<br />
+                                        Use only for legacy logos and mod images from mods predating Knossos.
+                                        If you create a new mod logo or image, use the above setting.
                                     </p>
 
                                     <button class="btn btn-small btn-default" @click.prevent="changeImage('logo')">Select Image</button>
@@ -856,7 +871,7 @@ export default {
                             <h4>-mod Flag</h4>
 
                             <p v-if="selected_mod.mod_flag.length < 1">
-                                No dependencies available. Please add your dependencies to the relevant packages and then
+                                No dependencies available. Add your dependencies to the relevant packages and then
                                 return here.
                             </p>
 

--- a/html/templates/kn-devel-page.vue
+++ b/html/templates/kn-devel-page.vue
@@ -606,7 +606,7 @@ export default {
             <div class="dev-instructions" v-else>
                 <p>
                     This tab has advanced features that can help you get started
-                    with FreeSpace Open modding.
+                    with modding for FreeSpace Open (FSO).
                 </p>
                 <p>
                     Here you can
@@ -619,13 +619,15 @@ export default {
                 </ul>
                 <p>
                     Players on Windows can also work with the mission editor FRED.
-                    <!-- TODO Include a link somewehre "for more information about FRED" to FS Wiki or FREDdocs or something. -->
                 </p>
                 <p>
-                     A version of FRED for all platforms called qtFRED is under development.
-                    <a href="https://www.hard-light.net/forums/index.php?topic=94565.0" class="open-ext">This forum thread</a> tracks its progress.
+                     A version of FRED for all platforms called qtFRED is available, but it's not yet as full-featured as FRED.<br>
+                    <a href="https://www.hard-light.net/forums/index.php?topic=94565.0" class="open-ext">This forum thread</a> tracks its development.
                 </p>
-                <!-- TODO including a few carefully chosen links to online modding resources might be a good use of space. -->
+                <p>
+                    Check out our <a href="https://docs.google.com/document/d/1oHq1YRc1eXbCgW-NqqKo1-6N_myfZzoBdwZuP16XImA/edit?pli=1#heading=h.fk85esz24kjw" class="open-ext">Mod Creation Guide</a>
+                    to help you get started.
+                </p>
             </div>
             <div class="form-box" v-if="selected_mod">
                 <div class="tabcorner"></div>
@@ -658,11 +660,11 @@ export default {
                         <div v-if="selected_mod.packages.length === 0">
                             <h4>Dev Help</h4>
 
-                            <p class="help-block">
+                            <p>
                                 You can't edit this mod since it doesn't have any packages, yet.
                             </p>
 
-                            <p class="help-block">
+                            <p>
                                 To create a package click the "+ Package" button on the left.<br>
                                 A package is simply a folder for mod resources.  Most mods will only ever need a single
                                 package that contains everything.  Multiple packages are handy for larger mods with
@@ -722,8 +724,10 @@ export default {
                                         <option value="mod">Mod</option>
                                         <option value="tc">Total Conversion</option>
                                         <option value="engine">FSO build</option>
+                                        <!-- TODO uncomment once extension and tool types are supported
                                         <option value="tool">Tool</option>
                                         <option value="ext">Extension</option>
+                                        -->
                                     </select>
 
                                     <span class="help-block" v-if="selected_mod.type === 'mod'">
@@ -736,9 +740,9 @@ export default {
                                     </span>
 
                                     <span class="help-block" v-if="selected_mod.type === 'engine'">
-                                        A build of the FreeSpace 2 Open (FSO) engine (fs2_open*.exe, fs2_open*.app, etc.)
+                                        A build of the FreeSpace 2 Open (FSO) engine (fs2_open*.exe, fs2_open*.AppImage, fs2_open*.app, etc.)
                                     </span>
-
+                                    <!-- TODO uncomment once tools and extensions are supported
                                     <span class="help-block" v-if="selected_mod.type === 'tool'">
                                         Software other than the FreeSpace 2 Open (FSO) engine
                                         Examples include FRED (mission editor) and PCS2 (model converter).
@@ -747,6 +751,7 @@ export default {
                                     <span class="help-block" v-if="selected_mod.type === 'ext'">
                                         A change that overrides, such as custom HUD tables
                                     </span>
+                                    -->
                                 </div>
                             </div>
 

--- a/html/templates/kn-devel-page.vue
+++ b/html/templates/kn-devel-page.vue
@@ -620,18 +620,16 @@ export default {
                     <li>edit installed mods</li>
                     <li>apply experimental mod settings</li>
                     <li>customize a mod's command line options (flags)</li>
+                    <li>make missions with the mission editors FRED (Windows only, full-featured) and qtFRED (all platforms, <a href="https://www.hard-light.net/forums/index.php?topic=94565.0" class="open-ext">under development</a>)</li>
                 </ul>
                 <p>
-                    Players on Windows can also make missions with the mission editor FRED.
+                    Check out these resources to help you get started:
                 </p>
-                <p>
-                     A version of FRED for all platforms called qtFRED is available, but it's not yet as full-featured as FRED.<br>
-                    <a href="https://www.hard-light.net/forums/index.php?topic=94565.0" class="open-ext">This forum thread</a> tracks its development.
-                </p>
-                <p>
-                    Check out our <a href="https://docs.google.com/document/d/1oHq1YRc1eXbCgW-NqqKo1-6N_myfZzoBdwZuP16XImA/edit?pli=1#heading=h.fk85esz24kjw" class="open-ext">Mod Creation Guide</a>
-                    to help you get started.
-                </p>
+                <ul>
+                    <li><a href="https://docs.google.com/document/d/1oHq1YRc1eXbCgW-NqqKo1-6N_myfZzoBdwZuP16XImA/edit?pli=1#heading=h.fk85esz24kjw" class="open-ext">Knossos Mod Creation Guide</a></li>
+                    <li><a href="http://fredzone.hard-light.net/freddocs/" class="open-ext">FREDdocs</a> classic FRED tutorial</li>
+                    <!-- TODO more -->
+                </ul>
             </div>
             <div class="form-box" v-if="selected_mod">
                 <div class="tabcorner"></div>
@@ -665,27 +663,43 @@ export default {
                             <h4>Dev Help</h4>
 
                             <p>
-                                You can't edit this mod because it doesn't have any packages yet.
+                                Your mod must have at least one package before you can start editing.
                             </p>
 
                             <p>
-                                A <em>package</em> is a folder for mod data (missions, new mdoels, etc.).
-                                Most mods need only one package that contains all of the mod's data.
-                                Splitting the data into multiple packages can be useful for larger mods,
-                                which might have a main package and optional packages for voice acting or high-detail models.
+                                A <em>package</em> is a folder for mod data (missions, models, etc).
+                                Smaller mods might need only one package that contains all of the mod's data.
+                                Larger mods should split their data into multiple packages, such as
                             </p>
+                            <ul>
+                                <li>Core for textual data such as missions and tables</li>
+                                <li>Models for new models and Maps for their textures</li>
+                                <li>Packages for media such as Movies, Music, Sound Effects, and Voice Acting</li>
+                                <li>Optional packages such as high-detail models/textures</li>
+                            </ul>
                             <p>
-                                <!-- TODO consistent terminology! what's the official term for Nebula? mod repository? server? Also what is its user-facing name? Nebula? FSNebula? FS Nebula? -->
-                                <!-- Just because the URL says fsnebula doesn't mean we have to call it "FS Nebula". I'm a fan of just calling it "Nebula". -->
-                                When you release your mod, you should pack each package into a single file called a <em>VP file</em>.
-                                VP file names end with ".vp". Knossos can automatically pack your package folders into
+                                When you release your mod, you should pack each package into an FSO-specific type of uncompressed file called a <em>VP file</em>.
+                                VP file names end with ".vp". Knossos can automatically pack your packages into
                                 VP files when you upload your mod to the <a href="https://fsnebula.org/" class="open-ext">Nebula</a> mod
                                 repository.
                             </p>
                             <p>
                                 To create a package, click the "+ Package" button on the left.<br>
-                                To edit a packge, click on the package name in the top tab list.
+                                To edit a package, click on the package name in the top tab list.
                             </p>
+                            <p>
+                                Some things to consider when deciding how to package your mod:
+                            </p>
+                            <ul>
+                                <li>A VP file can be at most 2 GB.</li>
+                                <li>Each compressed archive file on Nebula contains a single VP file.<br>
+                                Thus a player with an unreliable Internet connection who has to restart a download
+                                will benefit from your mod having packages that aren't huge.</li>
+                                <li>When you upload a new version of your mod, only modified packages are uploaded.<br>
+                                Thus if a new version has just mission fixes and your missions are in
+                                a separate package from models/textures, the new version will have a new missions
+                                package only, meaning a smaller upload for you and smaller downloads for players.</li>
+                            </ul>
                         </div>
                         <div v-else-if="!selected_pkg && page === 'details'">
                             <h4>Mod Details</h4>
@@ -894,7 +908,7 @@ export default {
                             </div>
                         </div>
 
-                        <div v-if="!selected_pkg && page === 'mod_flag'">
+                        <div v-else-if="!selected_pkg && page === 'mod_flag'">
                             <h4>-mod Flag</h4>
 
                             <p v-if="selected_mod.mod_flag.length < 1">
@@ -912,7 +926,7 @@ export default {
                             <kn-save-btn :save-handler="saveModFlag" />
                         </div>
 
-                        <div v-if="!selected_pkg && page === 'team'">
+                        <div v-else-if="!selected_pkg && page === 'team'">
                             <h4>Staff List</h4>
 
                             <p>

--- a/html/templates/kn-devel-page.vue
+++ b/html/templates/kn-devel-page.vue
@@ -679,7 +679,7 @@ export default {
                             <p>
                                 When you release your mod, you should pack each package into an FSO-specific type of uncompressed file called a <em>VP file</em>.
                                 VP file names end with ".vp". Knossos can automatically pack your packages into
-                                VP files when you upload your mod to the <a href="https://fsnebula.org/" class="open-ext">Nebula</a> mod
+                                VP files and compress them for you when you upload your mod to the <a href="https://fsnebula.org/" class="open-ext">Nebula</a> mod
                                 repository.
                             </p>
                             <p>
@@ -691,7 +691,7 @@ export default {
                             </p>
                             <ul>
                                 <li>A VP file can be at most 2 GB.</li>
-                                <li>Each compressed archive file on Nebula contains a single VP file.<br>
+                                <li>Knossos's automatic VP packing packs each VP file into its own compressed archive file.<br>
                                 Thus a player with an unreliable Internet connection who has to restart a download
                                 will benefit from your mod having packages that aren't huge.</li>
                                 <li>When you upload a new version of your mod, only modified packages are uploaded.<br>

--- a/html/templates/kn-devel-page.vue
+++ b/html/templates/kn-devel-page.vue
@@ -661,17 +661,26 @@ export default {
                             <h4>Dev Help</h4>
 
                             <p>
-                                You can't edit this mod since it doesn't have any packages, yet.
+                                You can't edit this mod because it doesn't have any packages yet.
                             </p>
 
                             <p>
-                                To create a package click the "+ Package" button on the left.<br>
-                                A package is simply a folder for mod resources.  Most mods will only ever need a single
-                                package that contains everything.  Multiple packages are handy for larger mods with
-                                different installation options.  For example, a larger mod could have a main package
-                                called 'main' and an optional voice package called 'voice'.<br>
-                                If you want to, Knossos can then pack everything in that folder automatically
-                                into a VP when you upload. Click on the package name in the top tab list to edit it.
+                                A <em>package</em> is a folder for mod data (missions, new mdoels, etc.).
+                                Most mods need only one package that contains all of the mod's data.
+                                Splitting the data into multiple packages can be useful for larger mods,
+                                which might have a main package and optional packages for voice acting or high-detail models.
+                            </p>
+                            <p>
+                                <!-- TODO consistent terminology! what's the official term for Nebula? mod repository? server? Also what is its user-facing name? Nebula? FSNebula? FS Nebula? -->
+                                <!-- Just because the URL says fsnebula doesn't mean we have to call it "FS Nebula". I'm a fan of just calling it "Nebula". -->
+                                When you release your mod, you should pack each package into a single file called a <em>VP file</em>.
+                                VP file names end with ".vp". Knossos can automatically pack your package folders into
+                                VP files when you upload your mod to the <a href="https://fsnebula.org/" class="open-ext">Nebula</a> mod
+                                repository.
+                            </p>
+                            <p>
+                                To create a package, click the "Modify Mod" tab on the left and then click the "+ Package" button.<br>
+                                To edit a packge, click on the package name in the top tab list.
                             </p>
                         </div>
                         <div v-else-if="!selected_pkg && page === 'details'">
@@ -731,20 +740,20 @@ export default {
                                     </select>
 
                                     <span class="help-block" v-if="selected_mod.type === 'mod'">
-                                        (Default) A campaign based either on FreeSpace 2 (retail) or on a total conversion (TC)<br>
+                                        A campaign based on FreeSpace 2 (retail) or on a total conversion (TC).<br>
                                     </span>
 
                                     <span class="help-block" v-if="selected_mod.type === 'tc'">
-                                        A standalone game that doesn't depend on other mods and doesn't use FS2 files<br>
-                                        Mods for TCs should still use the "Mod" type.
+                                        A standalone game that doesn't depend on other mods and doesn't use FS2 files.<br>
+                                        <strong>Mods for TCs should use the "Mod" type.</strong>
                                     </span>
 
                                     <span class="help-block" v-if="selected_mod.type === 'engine'">
-                                        A build of the FreeSpace 2 Open (FSO) engine (fs2_open*.exe, fs2_open*.AppImage, fs2_open*.app, etc.)
+                                        A build of the FreeSpace Open (FSO) engine (fs2_open*.exe, fs2_open*.AppImage, fs2_open*.app, etc.)
                                     </span>
                                     <!-- TODO uncomment once tools and extensions are supported
                                     <span class="help-block" v-if="selected_mod.type === 'tool'">
-                                        Software other than the FreeSpace 2 Open (FSO) engine
+                                        Software other than the FreeSpace Open (FSO) engine
                                         Examples include FRED (mission editor) and PCS2 (model converter).
                                     </span>
 

--- a/html/templates/kn-devel-page.vue
+++ b/html/templates/kn-devel-page.vue
@@ -161,6 +161,10 @@ export default {
             this.caps = null;
             this.video_urls = mod.videos.join("\n");
 
+            if(this.selected_mod.packages.length === 0) {
+                this.mod_box_tab = 'modify';
+            }
+
             this.tools = [];
             call(fs2mod.getModTools, this.selected_mod.id, this.selected_mod.version, (tools) => {
                 this.tools = tools;

--- a/html/templates/kn-devel-page.vue
+++ b/html/templates/kn-devel-page.vue
@@ -899,6 +899,9 @@ export default {
 
                         <div v-else-if="!selected_pkg && page === 'fso'">
                             <h4>FSO Settings</h4>
+                            <p>
+                                These settings apply when you run FSO from the Develop tab and will apply to players.
+                            </p>
 
                             <kn-fso-settings :mods="mods" :fso_build.sync="fso_build" :cmdline.sync="(selected_mod || {}).cmdline"></kn-fso-settings>
 

--- a/html/templates/kn-devel-page.vue
+++ b/html/templates/kn-devel-page.vue
@@ -582,7 +582,6 @@ export default {
                         <br>
                     </div>
 
-                    <!-- TODO for any button that brings up a dialog, add the "..." -->
                     <div class="buttonpane" v-if="mod_box_tab === 'modify'">
                         <button @click.prevent="reopenUploadPopup" class="mod-btn btn-link-blue" v-if="(this.mod_map[(this.selected_mod || {}).id] || {}).progress">Uploading...</button>
                         <button @click.prevent="uploadMod" class="mod-btn btn-link-blue" v-else>Upload</button><br>

--- a/html/templates/kn-fso-settings.vue
+++ b/html/templates/kn-fso-settings.vue
@@ -145,7 +145,7 @@ export default {
             <div class="col-xs-9">
                 <div class="input-group">
                     <select class="form-control" :value="fso_build" @input="$emit('update:fso_build', $event.target.value)">
-                        <option v-if="!isValidBuild()" :key="'invalid'" value="invalid">Please select a valid build</option>
+                        <option v-if="!isValidBuild()" :key="'invalid'" value="invalid">Select a valid build</option>
                         <option :value="null">{{ custom_build || 'Mod default' }}</option>
                         <option v-for="mod in engine_builds" :key="mod.id + '-' + mod.version" :value="mod.id + '#' + mod.version">
                             {{ mod.title }} {{ mod.version }}
@@ -163,7 +163,7 @@ export default {
             Not yet implemented
 
         <div class="form-group">
-            <label class="col-sm-4 control-label">Easy Setup:</label>
+            <label class="col-sm-4 control-label">Easy setup</label>
             <div class="col-sm-8">
                 <select class="form-control" v-model="selected_easy_flags">
                     <option value="">Select a group</option>
@@ -174,21 +174,21 @@ export default {
         -->
 
         <div class="form-group">
-            <label class="col-sm-4 control-label">Custom Flags:</label>
+            <label class="col-sm-4 control-label">Custom flags</label>
             <div class="col-sm-8">
                 <input type="text" class="form-control" v-model="custom_flags">
             </div>
         </div>
 
         <div class="form-group">
-            <label class="col-sm-4 control-label">Full Commandline:</label>
+            <label class="col-sm-4 control-label">Full command line</label>
             <div class="col-sm-8">
                 <textarea readonly class="form-control" rows="3">{{ loading_flags ? 'Loading...' : cmdline }}</textarea>
             </div>
         </div>
 
         <div class="form-group">
-            <label class="col-sm-4 control-label">List Type:</label>
+           <label class="col-sm-4 control-label">Flag list type</label>
             <div class="col-sm-8">
                 <select class="form-control" v-model="list_type">
                     <option v-for="(flags, name) in flags">{{ name }}</option>

--- a/html/templates/kn-fso-user-settings.vue
+++ b/html/templates/kn-fso-user-settings.vue
@@ -53,6 +53,9 @@ export default {
 </script>
 <template>
     <div>
+        <p v-if="mod.dev_mode">
+            These settings apply only to your Home tab. To make changes that will apply to players, use the Develop tab.
+        </p>
         <kn-fso-settings :mods="mods" :fso_build.sync="user_build" :cmdline.sync="mod.user_cmdline"></kn-fso-settings>
 
         <div class="form-group">

--- a/html/templates/kn-page.vue
+++ b/html/templates/kn-page.vue
@@ -512,30 +512,34 @@ export default {
                                     <option value="mod">Mod</option>
                                     <option value="tc" v-if="popup_mode === 'create_mod'">Total Conversion</option>
                                     <option value="engine" v-if="popup_mode === 'create_mod'">FSO build</option>
+                                    <!-- TODO uncomment once Tool and Extension are supported
                                     <option value="tool" v-if="popup_mode === 'create_mod'">Tool</option>
                                     <option value="ext">Extension</option>
+                                    -->
                                 </select>
 
                                 <span class="help-block" v-if="popup_mod_type === 'mod'">
-                                    This type is the default and covers most cases. Normally you'll want to use this type.
+                                    A campaign based on FreeSpace 2 (retail) or on a total conversion (TC).<br>
                                 </span>
 
                                 <span class="help-block" v-if="popup_mod_type === 'tc'">
-                                    Use this type if your mod doesn't depend on other mods or retail files.<br>
-                                    (Mods for TCs should still use the "Mod" type.)
+                                    A standalone game that doesn't depend on other mods and doesn't use FS2 files.<br>
+                                    Mods for TCs should use the "Mod" type.
                                 </span>
 
                                 <span class="help-block" v-if="popup_mod_type === 'engine'">
-                                    This should only be used for builds FSO builds (fs2_open*.exe, fs2_open*.AppImage, etc.).
+                                    A build of the FreeSpace Open (FSO) engine (fs2_open*.exe, fs2_open*.AppImage, fs2_open*.app, etc.)
                                 </span>
-
+                                <!-- TODO uncomment once tools and extensions are supported
                                 <span class="help-block" v-if="popup_mod_type === 'tool'">
-                                    This is used for all executables which aren't FSO like FRED or PCS2.
+                                    Software other than the FreeSpace Open (FSO) engine.<br>
+                                    Examples include FRED (mission editor) and PCS2 (model converter).
                                 </span>
 
                                 <span class="help-block" v-if="popup_mod_type === 'ext'">
-                                    This mod type is meant for overrides like custom HUD tables.
+                                    A change that overrides, such as custom HUD tables
                                 </span>
+                                -->
                             </div>
                         </div>
 
@@ -547,7 +551,7 @@ export default {
                                 </select>
 
                                 <span class="help-block">
-                                    Please select your parent TC here. If this mod doesn't extend a TC, select "Retail FS2".
+                                    The game your mod is based on, either FreeSpace 2 ("Retail FS2") or a total conversion (TC).
                                 </span>
                             </div>
                         </div>
@@ -616,7 +620,7 @@ export default {
 
                                 <label class="checkbox">
                                     <input type="radio" name="v_popup_mod_method" value="empty" v-model="popup_mod_method">
-                                    Create a new, empty folder
+                                    Create a new folder
                                 </label>
                             </div>
                         </div>
@@ -692,7 +696,7 @@ export default {
 
                 <div v-if="popup_mode == 'upload_mod'">
                     <p>
-                        Are you sure that you want to upload {{popup_mod_name}} {{popup_mod_version}}?
+                        Upload {{popup_mod_name}} {{popup_mod_version}} to Nebula?
                     </p>
 
                     <p>

--- a/html/templates/kn-page.vue
+++ b/html/templates/kn-page.vue
@@ -15,7 +15,7 @@ export default {
         tabs: {
             home: 'Home',
             explore: 'Explore',
-            develop: 'Development',
+            develop: 'Develop',
             trouble: 'Troubleshooting'
         },
 

--- a/knossos/runner.py
+++ b/knossos/runner.py
@@ -408,9 +408,12 @@ def run_mod(mod, tool=None, exe_label=None):
             translate('runner', 'The mod "%s" could not be found!') % mod)
         return
 
+    exes = []
+
     if tool:
         try:
             exes = tool.get_executables()
+            # TODO check whether repo.NoExecutablesFound exception applies here
         except Exception:
             logging.exception('Failed to retrieve binaries for "%s"!' % tool.mid)
             QtWidgets.QMessageBox.critical(None, translate('runner', 'Error'),
@@ -419,6 +422,13 @@ def run_mod(mod, tool=None, exe_label=None):
     else:
         try:
             exes = mod.get_executables(user=True)
+        except repo.NoExecutablesFound:
+            logging.error('"%s" provided no executable.' % mod.mid)
+            QtWidgets.QMessageBox.critical(
+                None, 'Knossos',
+                translate('runner', 'No executable was found for this mod!'
+                          ' Make sure you have an FSO build selected on the FSO tab.'))
+            return
         except Exception:
             logging.exception('Failed to retrieve binaries for "%s"!' % mod.mid)
             QtWidgets.QMessageBox.critical(None, translate('runner', 'Error'),

--- a/knossos/runner.py
+++ b/knossos/runner.py
@@ -424,10 +424,11 @@ def run_mod(mod, tool=None, exe_label=None):
             exes = mod.get_executables(user=True)
         except repo.NoExecutablesFound:
             logging.error('"%s" provided no executable.' % mod.mid)
+            msg = 'No executable was found for this mod!'
+            if mod.dev_mode:
+                msg += ' Make sure you have an FSO build selected on the FSO tab.'
             QtWidgets.QMessageBox.critical(
-                None, 'Knossos',
-                translate('runner', 'No executable was found for this mod!'
-                          ' Make sure you have an FSO build selected on the FSO tab.'))
+                None, 'Knossos', translate('runner', msg))
             return
         except Exception:
             logging.exception('Failed to retrieve binaries for "%s"!' % mod.mid)


### PR DESCRIPTION
**Note**: This is a WIP. I wanted to post what I have so far in case you already have feedback.

To explain why I prefer Develop for the tab name over Development, it's shorter and lines up nicely with the verb theme started by Explore. As mentioned inanother PR, I was gonna propose modifying the tab names so that each one is a (relatively) short verb. But that's up for discussion of course.

Btw why is the create mod popup in both `kn-page.vue` and `kn-devel-page.vue` ? I just realized I was editing the wrong template if I wanted to update that popup. Are any other dev tab popups duplicated like that, just so I know which page to edit?

Also, are the tabs called "tabs" or "pages" in player-facing text? We ran into this same question in wxL and I forget which one we chose, but picking one term and being consistent in player-facing text is important. I'm inclined towards "tab" myself.