### PR TITLE
Use delta updates when updating mod list

### DIFF
--- a/html/js/main.js
+++ b/html/js/main.js
@@ -249,6 +249,11 @@ function init() {
         if(res.welcome) {
             vm.page = 'welcome';
         }
+
+        let explore_mods = JSON.parse(res.explore_mods);
+        for(let mod_id of Object.keys(explore_mods)) {
+            explore_mod_table[mod_id] = explore_mods[mod_id];
+        }
     }), 300);
 
     window.addEventListener('error', (e) => {

--- a/html/templates/kn-page.vue
+++ b/html/templates/kn-page.vue
@@ -26,8 +26,6 @@ export default {
         show_filter: false,
         mods: [],
         mod_table: {},
-        installed_mod_table: {},
-        mod_order: [],
 
         // details page
         detail_mod: null,
@@ -77,40 +75,7 @@ export default {
         }
     },
 
-    computed: {
-        current_mod_table() {
-            return this.getCurrentModTable();
-        }
-
-    },
-
     methods: {
-        getCurrentModTable() {
-            if (this.tab === 'explore') {
-                return this.mod_table;
-            } else if (this.tab === 'home' || this.tab === 'develop') {
-                return this.installed_mod_table;
-            } else {
-                // FIXME TODO throw exception or warning or something
-                return this.mod_table;
-            }
-        },
-
-        computeCurrentMods(current_mod_table, mod_order) {
-            let mods = [];
-
-            for(let mid of mod_order) {
-                let mod = current_mod_table[mid];
-                if(mod) {
-                    mods.push(mod);
-                } else {
-                    // TODO print error/warning about mod not found in mod_table
-                }
-            }
-            
-            return mods;
-        },
-
         openLink(url) {
             fs2mod.openExternal(url);
         },
@@ -148,12 +113,8 @@ export default {
             }
         },
 
-        updateModlist(updated_mods, mod_order) {
-            let current_mod_table = this.getCurrentModTable();
-            for(let mid of Object.keys(updated_mods)) {
-                current_mod_table[mid] = updated_mods[mid]
-            }
-            this.mods = this.computeCurrentMods(current_mod_table, mod_order);
+        updateModlist(mods) {
+            this.mods = mods;
 
             if(next_tab) {
                 this.tab = next_tab;
@@ -163,10 +124,10 @@ export default {
                 first_load = false;
 
                 if(this.page !== 'welcome') {
-                    next_tab = this.mods.length === 0 ? 'explore' : 'home';
+                    next_tab = mods.length === 0 ? 'explore' : 'home';
                     fs2mod.showTab(next_tab);
                 }
-            } else if(this.page === 'details' && !current_mod_table[this.detail_mod]) {
+            } else if(this.page === 'details' && !mod_table[this.detail_mod]) {
                 // The currently visible mod has been uninstalled thus making displaying this page impossible.
                 // Switch to the tab instead
                 this.exitDetails();
@@ -408,7 +369,7 @@ export default {
 
         <kn-scroll-container v-if="page === 'details'" key="details" :dummy="detail_mod">
             <div class="info-page" id="details-page" slot-scope="{ update }">
-                <kn-details-page :modbundle="current_mod_table[detail_mod]" :updater="update"></kn-details-page>
+                <kn-details-page :modbundle="mod_table[detail_mod]" :updater="update"></kn-details-page>
             </div>
         </kn-scroll-container>
 

--- a/knossos/web.py
+++ b/knossos/web.py
@@ -141,7 +141,8 @@ class WebBridge(QtCore.QObject):
         return json.dumps({
             't': trs,
             'platform': sys.platform,
-            'welcome': 'KN_WELCOME' in os.environ or center.settings['base_path'] is None
+            'welcome': 'KN_WELCOME' in os.environ or center.settings['base_path'] is None,
+            'explore_mods': center.main_win.get_explore_mod_list_cache_json()
         })
 
     @QtCore.Slot(result=str)

--- a/knossos/web.py
+++ b/knossos/web.py
@@ -71,7 +71,7 @@ class WebBridge(QtCore.QObject):
     showRetailPrompt = QtCore.Signal()
     showLaunchPopup = QtCore.Signal(str)
     showModDetails = QtCore.Signal(str)
-    updateModlist = QtCore.Signal(str, str)
+    updateModlist = QtCore.Signal(str, str, list)
     modProgress = QtCore.Signal(str, float, str)
     retailInstalled = QtCore.Signal()
     hidePopup = QtCore.Signal()

--- a/knossos/windows.py
+++ b/knossos/windows.py
@@ -259,7 +259,7 @@ class HellWindow(Window):
     _updating_mods = None
     _init_done = False
     _prg_visible = False
-    _mod_list_cache = None
+    _explore_mod_list_cache = None
     _installed_mod_list_cache = None
     browser_ctrl = None
     progress_win = None
@@ -268,7 +268,7 @@ class HellWindow(Window):
         super(HellWindow, self).__init__(window)
         self._tasks = {}
         self._updating_mods = {}
-        self._mod_list_cache = {}
+        self._explore_mod_list_cache = {}
         self._installed_mod_list_cache = {}
 
         self._create_win(Ui_Hell, QMainWindow)
@@ -476,24 +476,20 @@ class HellWindow(Window):
         return result, self._mod_filter
 
     def _compute_mod_list_diff(self, new_mod_list):
-        current_mod_list_cache = None
+        mod_list_cache = None
         if self._mod_filter in ('home', 'develop'):
-            current_mod_list_cache = self._installed_mod_list_cache
+            mod_list_cache = self._installed_mod_list_cache
         elif self._mod_filter == 'explore':
-            current_mod_list_cache = self._mod_list_cache
+            mod_list_cache = self._explore_mod_list_cache
         else:
             raise Exception('_compute_mod_list_diff: unknown mod filter type %s' % self._mod_filter)
 
         updated_mods = {}
         for item in new_mod_list:
-            try:
-                old_item = current_mod_list_cache.get(item['id'], None)
-            except Exception:
-                logging.error('mid not foudn in current item! %s', item)
-                raise
+            old_item = mod_list_cache.get(item['id'], None)
             if item != old_item:
                 updated_mods[item['id']] = item
-                current_mod_list_cache[item['id']] = item
+                mod_list_cache[item['id']] = item
 
         return updated_mods
 


### PR DESCRIPTION
Addresses issue #154  and based on the solution proposed there. Still a bit of a WIP but tests are promising.

~~Known issue: the first time you switch from the Home tab to the Explore tab, there's that same 2-3 second delay that there currently is, but switching to Explore is fast after that. The reason is that I haven't (yet?) added support for warming the Explore cache at Knossos startup. I'll need to figure out a relatively clean way to warm the cache using the existing code paths.~~

EDIT: new commit initializes the explore mod list cache at startup. There is still a slight delay the first time you switch from the Home tab to the Explore tab but it's noticeably shorter than before and about as short as I can make it without per-field deltas which is not worth the extra work/difficulty IMO