### PR TITLE
Always remove the 'no_hide' parameter for check_output

### DIFF
--- a/knossos/util.py
+++ b/knossos/util.py
@@ -271,13 +271,14 @@ def check_output(*args, **kwargs):
         kwargs.setdefault('stdin', subprocess.DEVNULL)
         kwargs.setdefault('stderr', subprocess.DEVNULL)
 
-        if kwargs.get('no_hide'):
-            del kwargs['no_hide']
-        else:
+        if not kwargs.get('no_hide'):
             si = subprocess.STARTUPINFO()
             si.dwFlags = subprocess.STARTF_USESHOWWINDOW
             si.wShowWindow = subprocess.SW_HIDE
             kwargs['startupinfo'] = si
+
+    # Remove the no_hide parameter that is irrelevant to subprocess.check_output
+    kwargs.pop('no_hide', None)
 
     kwargs.setdefault('errors', 'surrogateescape')
     kwargs.setdefault('universal_newlines', True)


### PR DESCRIPTION
The parameter is irrelevant for that function which causes an error when
trying to execute subprocess.check_output with that enabled. This always
removes that key from the arguments after handling it within the
function.