### PR TITLE
Hide FSO builds from mod list by default

### DIFF
--- a/html/templates/kn-settings-page.vue
+++ b/html/templates/kn-settings-page.vue
@@ -77,7 +77,7 @@ export default {
                 fs2mod.setBasePath(this.knossos.base_path);
             }
 
-            for(let set of ['max_downloads', 'use_raven', 'engine_stability', 'download_bandwidth', 'update_notify', 'custom_bar', 'show_fs2_mods_without_retail']) {
+            for(let set of ['max_downloads', 'use_raven', 'engine_stability', 'download_bandwidth', 'update_notify', 'custom_bar', 'show_fs2_mods_without_retail', 'show_fso_builds']) {
                 if(this.knossos[set] != this.old_settings.knossos[set]) {
                     fs2mod.saveSetting(set, JSON.stringify(this.knossos[set]));
                 }
@@ -175,6 +175,13 @@ export default {
                     <label class="col-sm-4 control-label">Show FreeSpace 2 Mods:</label>
                     <div class="col-sm-8">
                         <input type="checkbox" v-model="knossos.show_fs2_mods_without_retail">
+                    </div>
+                </div>
+
+                <div class="form-group">
+                    <label class="col-sm-4 control-label">Show Engine Builds In Mod List:</label>
+                    <div class="col-sm-8">
+                        <input type="checkbox" v-model="knossos.show_fso_builds">
                     </div>
                 </div>
             </kn-drawer>

--- a/knossos/center.py
+++ b/knossos/center.py
@@ -71,7 +71,8 @@ settings = {
         'guid': None,
         'id': 99999
     },
-    'show_fs2_mods_without_retail': False
+    'show_fs2_mods_without_retail': False,
+    'show_fso_builds': False
 }
 
 if sys.platform.startswith('win'):

--- a/knossos/windows.py
+++ b/knossos/windows.py
@@ -381,6 +381,9 @@ class HellWindow(Window):
                 mod = mvs[0]
                 
                 if mod.mtype == 'engine' and self._mod_filter != 'develop':
+                    if not center.settings['show_fso_builds']:
+                        continue
+
                     mvs = [mv for mv in mvs if mv.satisfies_stability(center.settings['engine_stability'])]
                     if len(mvs) == 0:
                         mvs = mods[mid]


### PR DESCRIPTION
Hide FSO builds from the Home/Explore tabs (they are not excluded from Develop) with a setting to show them.

Based on AcePilot's experience in the [Knossos release thread,](https://www.hard-light.net/forums/index.php?topic=94068.msg1880160#msg1880160) showing mainstream FSO and other engine builds (e.g., WoD) alongside mods is confusing to players, because the build entries look the same as playable mods in the list but don't have a Play button.

Furthermore, the large majority of players want to download entire mods and not specific builds. The use case of downloading just builds is an edge case.

As with FS2 mods when retail is not installed, it might be good to visually indicate that a mod list item is an FSO build and not a playable mod. I'll try a little playing around and see if I can come uop with something analogous to PR #148 . EDIT: no ideas at the moment and I don't want to add clutter to the UI. Maybe ensuring that mod list entries for builds include "Builds" in the title is good enough.