### PR TITLE
Fix issues introduced by new semantic-version ... version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ __pycache__
 build
 dist
 version-rthook.py
+/knossos/parser.out
 /knossos/ui/*
 /knossos/data/resources.rcc
 /knossos/data/resources.qrc

--- a/knossos/repo.py
+++ b/knossos/repo.py
@@ -483,7 +483,7 @@ class Mod(object):
         self.mid = values['id']
         self.title = values['title']
         self.mtype = values.get('type', 'mod')  # Backwards compatibility
-        self.version = semantic_version.Version(values['version'], partial=True)
+        self.version = semantic_version.Version.coerce(values['version'])
         self.stability = values.get('stability', 'stable')
         self.parent = values.get('parent', 'FS2')
         self.cmdline = values.get('cmdline', '')

--- a/knossos/web.py
+++ b/knossos/web.py
@@ -241,7 +241,7 @@ class WebBridge(QtCore.QObject):
                 spec = None
             else:
                 if re.search(r'^\d+', spec):
-                    spec = '==' + spec
+                    spec = '==' + str(semantic_version.Version.coerce(spec))
 
                 try:
                     spec = util.Spec(spec)


### PR DESCRIPTION
There were some changes in how "partial" version were handled and
Knossos relied on the old behavior. I hope that this should fix the
issues by filling in missing parts of the versions where necessary.