### PR TITLE
fix/macbuilds: Fix building a Knossos DMG for macOS

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -204,7 +204,7 @@ with open('build.ninja', 'w') as stream:
         n.comment('macOS')
 
         if check_module('PyInstaller', required=False):
-            pyinstaller = 'cd releng/macos && ' + cmd2str([sys.executable, '-O', '-mPyInstaller', '-d', '--distpath=./dist', '--workpath=./build', 'Knossos.spec', '-y'])
+            pyinstaller = 'cd releng/macos && ' + cmd2str([sys.executable, '-O', '-mPyInstaller', '-D', '--distpath=./dist', '--workpath=./build', 'Knossos.spec', '-y'])
             n.rule('pyinstaller', pyinstaller, 'PACKAGE', pool='console')
             n.build('pyi', 'pyinstaller', ['resources'] + SRC_FILES)
 

--- a/releng/macos/Vagrantfile
+++ b/releng/macos/Vagrantfile
@@ -1,5 +1,7 @@
 Vagrant.configure("2") do |config|
   config.vm.define "knossos-builder"
+  # config.vm.box = "ramsey/macos-catalina"
+  # config.vm.box_version = "1.0.0"
   config.vm.box = "jhcook/macos-sierra"
 
   config.vm.synced_folder ".", "/vagrant", disabled: true

--- a/releng/macos/auto-build.sh
+++ b/releng/macos/auto-build.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+source /Users/vagrant/.profile
+
 export PATH="/usr/local/bin:$PATH:/Library/Frameworks/Python.framework/Versions/3.6/bin:/usr/local/opt/qt5/bin"
 export LANG="en_US.UTF-8"
 

--- a/releng/macos/build.sh
+++ b/releng/macos/build.sh
@@ -7,4 +7,6 @@ rm -rf dist/*
 
 vagrant rsync
 vagrant ssh -- 'bash /opt/knossos/releng/macos/auto-build.sh'
-rsync -e 'ssh -F ssh_config' -ar knossos-builder:/opt/knossos/releng/macos/dist .
+vagrant ssh-config > /tmp/ssh_config
+rsync -e 'ssh -F /tmp/ssh_config' -ar knossos-builder:/opt/knossos/releng/macos/dist .
+rm /tmp/ssh_config

--- a/releng/macos/provision.sh
+++ b/releng/macos/provision.sh
@@ -2,13 +2,49 @@
 
 set -eo pipefail
 
+# To prevent python pipenv error during init script
+# "Click will abort further execution because Python 3 was configured to use ASCII as encoding for the environment."
+# https://click.palletsprojects.com/en/7.x/python3/
+export LC_ALL=en_US.UTF-8
+export LANG=en_US.UTF-8
+
+##### START from Mokacoding (https://www.mokacoding.com/blog/how-to-install-xcode-cli-tools-without-gui/)
+# See http://apple.stackexchange.com/questions/107307/how-can-i-install-the-command-line-tools-completely-from-the-command-line
+
+echo "Checking Xcode CLI tools"
+# Only run if the tools are not installed yet
+# To check that try to print the SDK path
+if [ xcode-select -p &> /dev/null ]; then
+  echo "Xcode CLI tools OK"
+else
+  echo "Xcode CLI tools not found. Installing them..."
+  touch /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress;
+  PROD=$(softwareupdate -l |
+    grep "\*.*Command Line" |
+    head -n 1 | awk -F"*" '{print $2}' |
+    sed -e 's/^ *//' |
+    tr -d '\n')
+  softwareupdate -i "$PROD";
+fi
+##### END from Mokacoding
+
+echo "==> Installing Node nvm"
+touch /Users/vagrant/.profile
+chown Vagrant:staff /Users/vagrant/.profile
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
+nvm install 14.1.0 # Matches current version in brew
+
+echo "==> Installing Yarn"
+curl -o- -L https://yarnpkg.com/install.sh | bash
+
 echo "==> Installing Homebrew"
-ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+# Pretened to be CI Bot, enables silent install, must install Dev Tools first (see above)
+CI=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 
 echo "==> Installing build tools"
-brew update
-brew upgrade
-brew install node p7zip ninja qt5 yarn
+brew install p7zip ninja
 
 # If we don't delete qmake, PyInstaller detects this Qt installation and uses its libraries instead of PyQt5's
 # which then leads to a crash because PyQt5 isn't compatible with the version we install.
@@ -18,23 +54,38 @@ mkdir /tmp/prov
 cd /tmp/prov
 
 # We need Python 3.6 since that's the latest version PyInstaller supports.
-echo "==> Installing Python 3.6.6"
-curl -so python.pkg "https://www.python.org/ftp/python/3.6.6/python-3.6.6-macosx10.6.pkg"
+# Update: PyInstaller supports 3.7 now but couldn't get things to cooperate with it.
+# Also this needs to agree with the version in the Pipfile.
+echo "==> Installing Python 3.6.8"
+curl -so python.pkg "https://www.python.org/ftp/python/3.6.8/python-3.6.8-macosx10.9.pkg"
 sudo installer -store -pkg python.pkg -target /
 
 export PATH="/Library/Frameworks/Python.framework/Versions/3.6/bin:$PATH"
 
-echo "==> Installing Python dependencies"
-pip3 install -U pip pipenv
-pipenv install --system --deploy
-
 echo "==> Installing SDL2"
-curl -so SDL2.dmg "https://libsdl.org/release/SDL2-2.0.8.dmg"
+curl -so SDL2.dmg "https://libsdl.org/release/SDL2-2.0.12.dmg"
 
 dev="$(hdiutil attach SDL2.dmg | tail -n1 | awk '{ print $3 }')"
 sudo cp -a "$dev/SDL2.framework" /Library/Frameworks
 hdiutil detach "$dev"
+rm SDL2.dmg
+
+# Visit script URL for info.  From 'Cubes' (qbs)
+echo "==> Installing Qt5 (base and tools)"
+curl -o install-qt.sh https://code.qt.io/cgit/qbs/qbs.git/plain/scripts/install-qt.sh
+chmod +x install-qt.sh
+# See below URL for examples on what packages are available for a version
+# https://download.qt.io/online/qtsdkrepository/mac_x64/desktop/qt5_598/qt.qt5.598.clang_64/
+# Should agree with Pipfile PyQt5 version and path in auto-build.sh
+./install-qt.sh --directory /usr/local/opt/Qt --version 5.10.1 qtbase qttools
+ln -s /usr/local/opt/Qt/5.10.1/clang_64 /usr/local/opt/qt5
 
 echo "==> Cleanup"
 cd ..
 rm -r prov
+
+echo "==> Installing Python dependencies"
+# Seems like we need to go to the knossos folder before running pipenv
+cd /opt/knossos
+pip3 install -U pip pipenv wheel macholib
+pipenv install --system --deploy


### PR DESCRIPTION
Still uses 10.12 to build, but runs on 10.15 just fine.

I have it to where all that is needed to generate a build is to run `vagrant up` inside the releng/macos folder, and then after that is up and provisioned, `./build.sh` will create the build, and rsync it out of the VM into the local machine's releng/macos/dist folder.