### PR TITLE
Specify a login shell instead of manually loading profile

### DIFF
--- a/releng/macos/auto-build.sh
+++ b/releng/macos/auto-build.sh
@@ -2,8 +2,6 @@
 
 set -e
 
-source /Users/vagrant/.profile
-
 export PATH="/usr/local/bin:$PATH:/Library/Frameworks/Python.framework/Versions/3.6/bin:/usr/local/opt/qt5/bin"
 export LANG="en_US.UTF-8"
 

--- a/releng/macos/build.sh
+++ b/releng/macos/build.sh
@@ -6,7 +6,7 @@ cd "$(dirname "$0")"
 rm -rf dist/*
 
 vagrant rsync
-vagrant ssh -- 'bash /opt/knossos/releng/macos/auto-build.sh'
+vagrant ssh -- 'bash --login /opt/knossos/releng/macos/auto-build.sh'
 vagrant ssh-config > /tmp/ssh_config
 rsync -e 'ssh -F /tmp/ssh_config' -ar knossos-builder:/opt/knossos/releng/macos/dist .
 rm /tmp/ssh_config


### PR DESCRIPTION
Should have done this in the first place probably, this is a much cleaner way to solve the problem that doesn't put any Vagrant-specific code in the auto-build.sh, since this is shared with the CI system as well.