### PR TITLE
Make Travis builds more like VM builds

### DIFF
--- a/releng/ci/travis_provision.sh
+++ b/releng/ci/travis_provision.sh
@@ -4,6 +4,8 @@ set -exo pipefail
 base="$(pwd)"
 
 if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+    brew uninstall --force qt
+
     DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
     cd "${DIR}"/../macos
 
@@ -13,16 +15,12 @@ if [ "$TRAVIS_OS_NAME" == "osx" ]; then
 
     install_brews
 
-    # If we don't delete qmake, PyInstaller detects this Qt installation and uses its libraries instead of PyQt5's
-    # which then leads to a crash because PyQt5 isn't compatible with the version we install.
-    sudo rm -f /usr/local/Cellar/qt/*/bin/qmake
-
     mkdir /tmp/prov
     cd /tmp/prov
 
     install_SDL2
 
-    # install_qt5
+    install_qt5
 
     install_python
 

--- a/releng/macos/Vagrantfile
+++ b/releng/macos/Vagrantfile
@@ -1,8 +1,19 @@
 Vagrant.configure("2") do |config|
   config.vm.define "knossos-builder"
+
   # config.vm.box = "ramsey/macos-catalina"
   # config.vm.box_version = "1.0.0"
-  config.vm.box = "jhcook/macos-sierra"
+
+  # config.vm.box = "gobadiah/macos-mojave"
+  # config.vm.box_version = "10.14.6"
+
+  config.vm.box = "vagrant-appunite/macos10.13.5"
+  config.vm.box_version = "1.0"
+
+  # config.vm.box = "thealanberman/macos-10.13.4"
+  # config.vm.box_version = "201805.23.0"
+
+  # config.vm.box = "jhcook/macos-sierra"
 
   config.vm.synced_folder ".", "/vagrant", disabled: true
   config.vm.synced_folder "../..", "/opt/knossos", group: "wheel", type: "rsync",

--- a/releng/macos/functions.sh
+++ b/releng/macos/functions.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+install_clitools(){
+  ##### START from Mokacoding (https://www.mokacoding.com/blog/how-to-install-xcode-cli-tools-without-gui/)
+  # See http://apple.stackexchange.com/questions/107307/how-can-i-install-the-command-line-tools-completely-from-the-command-line
+
+  echo "Checking Xcode CLI tools"
+  # Only run if the tools are not installed yet
+  # To check that try to print the SDK path
+  if [ xcode-select -p &> /dev/null ]; then
+    echo "Xcode CLI tools OK"
+  else
+    echo "Xcode CLI tools not found. Installing them..."
+    touch /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress;
+    PROD=$(softwareupdate -l |
+      grep "\*.*Command Line" |
+      head -n 1 | awk -F"*" '{print $2}' |
+      sed -e 's/^ *//' |
+      tr -d '\n')
+    softwareupdate -i "$PROD";
+  fi
+  ##### END from Mokacoding
+}
+
+install_nvm(){
+  echo "==> Installing Node nvm"
+  touch /Users/vagrant/.profile
+  chown Vagrant:staff /Users/vagrant/.profile
+  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
+  export NVM_DIR="$HOME/.nvm"
+  [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
+  nvm install 14.1.0 # Matches current version in brew
+}
+
+install_yarn(){
+  echo "==> Installing Yarn"
+  curl -o- -L https://yarnpkg.com/install.sh | bash
+}
+
+install_homebrew(){
+  echo "==> Installing Homebrew"
+  # Pretened to be CI Bot, enables silent install, must install Dev Tools first (see above)
+  CI=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+}
+
+install_brews(){
+  # Don't waste time on updating Homebrew.
+  export HOMEBREW_NO_AUTO_UPDATE=1
+
+  echo "==> Installing build tools"
+  brew install --force-bottle p7zip ninja
+}
+
+install_python(){
+  # We need Python 3.6 since that's the latest version PyInstaller supports.
+  # Update: PyInstaller supports 3.7 now but couldn't get things to cooperate with it.
+  # Also this needs to agree with the version in the Pipfile.
+  echo "==> Installing Python 3.6.8"
+  curl -so python.pkg "https://www.python.org/ftp/python/3.6.8/python-3.6.8-macosx10.9.pkg"
+  sudo installer -store -pkg python.pkg -target /
+
+  export PATH="/Library/Frameworks/Python.framework/Versions/3.6/bin:$PATH"
+}
+
+install_SDL2(){
+  echo "==> Installing SDL2"
+  curl -so SDL2.dmg "https://libsdl.org/release/SDL2-2.0.12.dmg"
+
+  dev="$(hdiutil attach SDL2.dmg | tail -n1 | awk '{ print $3 }')"
+  sudo cp -a "$dev/SDL2.framework" /Library/Frameworks
+  hdiutil detach "$dev"
+  rm SDL2.dmg
+}
+
+install_qt5(){
+  # Visit script URL for info.  From 'Cubes' (qbs)
+  echo "==> Installing Qt5 (base and tools)"
+  curl -o install-qt.sh https://raw.githubusercontent.com/qbs/qbs/faa280045d783d2fbe815fa83c8c143faf02ecf7/scripts/install-qt.sh
+  chmod +x install-qt.sh
+  # See below URL for examples on what packages are available for a version
+  # https://download.qt.io/online/qtsdkrepository/mac_x64/desktop/qt5_598/qt.qt5.598.clang_64/
+  # Should agree with Pipfile PyQt5 version and path in auto-build.sh
+  ./install-qt.sh --directory /usr/local/opt/Qt --version 5.10.1 qtbase qttools
+  ln -s /usr/local/opt/Qt/5.10.1/clang_64 /usr/local/opt/qt5
+}
+
+install_pideps(){
+  # To prevent python pipenv error during init script
+  # "Click will abort further execution because Python 3 was configured to use ASCII as encoding for the environment."
+  # https://click.palletsprojects.com/en/7.x/python3/
+  export LC_ALL=en_US.UTF-8
+  export LANG=en_US.UTF-8
+
+  echo "==> Installing Python dependencies"
+  # Seems like we need to go to the knossos folder before running pipenv
+  pip3 install -U pip pipenv wheel macholib
+  pipenv install --system --deploy
+}

--- a/releng/macos/provision.sh
+++ b/releng/macos/provision.sh
@@ -3,103 +3,10 @@
 set -eo pipefail
 base=/opt/knossos
 
-## BEGIN FUNCTIONS ##
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd "${DIR}"
 
-install_clitools(){
-  ##### START from Mokacoding (https://www.mokacoding.com/blog/how-to-install-xcode-cli-tools-without-gui/)
-  # See http://apple.stackexchange.com/questions/107307/how-can-i-install-the-command-line-tools-completely-from-the-command-line
-
-  echo "Checking Xcode CLI tools"
-  # Only run if the tools are not installed yet
-  # To check that try to print the SDK path
-  if [ xcode-select -p &> /dev/null ]; then
-    echo "Xcode CLI tools OK"
-  else
-    echo "Xcode CLI tools not found. Installing them..."
-    touch /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress;
-    PROD=$(softwareupdate -l |
-      grep "\*.*Command Line" |
-      head -n 1 | awk -F"*" '{print $2}' |
-      sed -e 's/^ *//' |
-      tr -d '\n')
-    softwareupdate -i "$PROD";
-  fi
-  ##### END from Mokacoding
-}
-
-install_nvm(){
-  echo "==> Installing Node nvm"
-  touch /Users/vagrant/.profile
-  chown Vagrant:staff /Users/vagrant/.profile
-  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
-  export NVM_DIR="$HOME/.nvm"
-  [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
-  nvm install 14.1.0 # Matches current version in brew
-}
-
-install_yarn(){
-  echo "==> Installing Yarn"
-  curl -o- -L https://yarnpkg.com/install.sh | bash
-}
-
-install_homebrew(){
-  echo "==> Installing Homebrew"
-  # Pretened to be CI Bot, enables silent install, must install Dev Tools first (see above)
-  CI=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
-}
-
-install_brews(){
-  echo "==> Installing build tools"
-  brew install p7zip ninja
-}
-
-install_python(){
-  # We need Python 3.6 since that's the latest version PyInstaller supports.
-  # Update: PyInstaller supports 3.7 now but couldn't get things to cooperate with it.
-  # Also this needs to agree with the version in the Pipfile.
-  echo "==> Installing Python 3.6.8"
-  curl -so python.pkg "https://www.python.org/ftp/python/3.6.8/python-3.6.8-macosx10.9.pkg"
-  sudo installer -store -pkg python.pkg -target /
-
-  export PATH="/Library/Frameworks/Python.framework/Versions/3.6/bin:$PATH"
-}
-
-install_SDL2(){
-  echo "==> Installing SDL2"
-  curl -so SDL2.dmg "https://libsdl.org/release/SDL2-2.0.12.dmg"
-
-  dev="$(hdiutil attach SDL2.dmg | tail -n1 | awk '{ print $3 }')"
-  sudo cp -a "$dev/SDL2.framework" /Library/Frameworks
-  hdiutil detach "$dev"
-  rm SDL2.dmg
-}
-
-install_qt5(){
-  # Visit script URL for info.  From 'Cubes' (qbs)
-  echo "==> Installing Qt5 (base and tools)"
-  curl -o install-qt.sh https://raw.githubusercontent.com/qbs/qbs/faa280045d783d2fbe815fa83c8c143faf02ecf7/scripts/install-qt.sh
-  chmod +x install-qt.sh
-  # See below URL for examples on what packages are available for a version
-  # https://download.qt.io/online/qtsdkrepository/mac_x64/desktop/qt5_598/qt.qt5.598.clang_64/
-  # Should agree with Pipfile PyQt5 version and path in auto-build.sh
-  ./install-qt.sh --directory /usr/local/opt/Qt --version 5.10.1 qtbase qttools
-  ln -s /usr/local/opt/Qt/5.10.1/clang_64 /usr/local/opt/qt5
-}
-
-install_pideps(){
-  # To prevent python pipenv error during init script
-  # "Click will abort further execution because Python 3 was configured to use ASCII as encoding for the environment."
-  # https://click.palletsprojects.com/en/7.x/python3/
-  export LC_ALL=en_US.UTF-8
-  export LANG=en_US.UTF-8
-
-  echo "==> Installing Python dependencies"
-  # Seems like we need to go to the knossos folder before running pipenv
-  pip3 install -U pip pipenv wheel macholib
-  pipenv install --system --deploy
-}
-
-## END FUNCTIONS ##
+source ./functions.sh
 
 install_clitools
 
@@ -111,21 +18,17 @@ install_homebrew
 
 install_brews
 
-# If we don't delete qmake, PyInstaller detects this Qt installation and uses its libraries instead of PyQt5's
-# which then leads to a crash because PyQt5 isn't compatible with the version we install.
-#rm -f /usr/local/Cellar/qt/*/bin/qmake
-
 mkdir /tmp/prov
 cd /tmp/prov
-
-install_python
 
 install_SDL2
 
 install_qt5
 
+install_python
+
 echo "==> Cleanup"
-cd "$base"
+cd "${base}"
 rm -r /tmp/prov
 
 install_pideps

--- a/releng/macos/provision.sh
+++ b/releng/macos/provision.sh
@@ -1,50 +1,115 @@
 #!/bin/bash
 
 set -eo pipefail
+base=/opt/knossos
 
-# To prevent python pipenv error during init script
-# "Click will abort further execution because Python 3 was configured to use ASCII as encoding for the environment."
-# https://click.palletsprojects.com/en/7.x/python3/
-export LC_ALL=en_US.UTF-8
-export LANG=en_US.UTF-8
+## BEGIN FUNCTIONS ##
 
-##### START from Mokacoding (https://www.mokacoding.com/blog/how-to-install-xcode-cli-tools-without-gui/)
-# See http://apple.stackexchange.com/questions/107307/how-can-i-install-the-command-line-tools-completely-from-the-command-line
+install_clitools(){
+  ##### START from Mokacoding (https://www.mokacoding.com/blog/how-to-install-xcode-cli-tools-without-gui/)
+  # See http://apple.stackexchange.com/questions/107307/how-can-i-install-the-command-line-tools-completely-from-the-command-line
 
-echo "Checking Xcode CLI tools"
-# Only run if the tools are not installed yet
-# To check that try to print the SDK path
-if [ xcode-select -p &> /dev/null ]; then
-  echo "Xcode CLI tools OK"
-else
-  echo "Xcode CLI tools not found. Installing them..."
-  touch /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress;
-  PROD=$(softwareupdate -l |
-    grep "\*.*Command Line" |
-    head -n 1 | awk -F"*" '{print $2}' |
-    sed -e 's/^ *//' |
-    tr -d '\n')
-  softwareupdate -i "$PROD";
-fi
-##### END from Mokacoding
+  echo "Checking Xcode CLI tools"
+  # Only run if the tools are not installed yet
+  # To check that try to print the SDK path
+  if [ xcode-select -p &> /dev/null ]; then
+    echo "Xcode CLI tools OK"
+  else
+    echo "Xcode CLI tools not found. Installing them..."
+    touch /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress;
+    PROD=$(softwareupdate -l |
+      grep "\*.*Command Line" |
+      head -n 1 | awk -F"*" '{print $2}' |
+      sed -e 's/^ *//' |
+      tr -d '\n')
+    softwareupdate -i "$PROD";
+  fi
+  ##### END from Mokacoding
+}
 
-echo "==> Installing Node nvm"
-touch /Users/vagrant/.profile
-chown Vagrant:staff /Users/vagrant/.profile
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
-export NVM_DIR="$HOME/.nvm"
-[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
-nvm install 14.1.0 # Matches current version in brew
+install_nvm(){
+  echo "==> Installing Node nvm"
+  touch /Users/vagrant/.profile
+  chown Vagrant:staff /Users/vagrant/.profile
+  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
+  export NVM_DIR="$HOME/.nvm"
+  [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
+  nvm install 14.1.0 # Matches current version in brew
+}
 
-echo "==> Installing Yarn"
-curl -o- -L https://yarnpkg.com/install.sh | bash
+install_yarn(){
+  echo "==> Installing Yarn"
+  curl -o- -L https://yarnpkg.com/install.sh | bash
+}
 
-echo "==> Installing Homebrew"
-# Pretened to be CI Bot, enables silent install, must install Dev Tools first (see above)
-CI=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+install_homebrew(){
+  echo "==> Installing Homebrew"
+  # Pretened to be CI Bot, enables silent install, must install Dev Tools first (see above)
+  CI=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+}
 
-echo "==> Installing build tools"
-brew install p7zip ninja
+install_brews(){
+  echo "==> Installing build tools"
+  brew install p7zip ninja
+}
+
+install_python(){
+  # We need Python 3.6 since that's the latest version PyInstaller supports.
+  # Update: PyInstaller supports 3.7 now but couldn't get things to cooperate with it.
+  # Also this needs to agree with the version in the Pipfile.
+  echo "==> Installing Python 3.6.8"
+  curl -so python.pkg "https://www.python.org/ftp/python/3.6.8/python-3.6.8-macosx10.9.pkg"
+  sudo installer -store -pkg python.pkg -target /
+
+  export PATH="/Library/Frameworks/Python.framework/Versions/3.6/bin:$PATH"
+}
+
+install_SDL2(){
+  echo "==> Installing SDL2"
+  curl -so SDL2.dmg "https://libsdl.org/release/SDL2-2.0.12.dmg"
+
+  dev="$(hdiutil attach SDL2.dmg | tail -n1 | awk '{ print $3 }')"
+  sudo cp -a "$dev/SDL2.framework" /Library/Frameworks
+  hdiutil detach "$dev"
+  rm SDL2.dmg
+}
+
+install_qt5(){
+  # Visit script URL for info.  From 'Cubes' (qbs)
+  echo "==> Installing Qt5 (base and tools)"
+  curl -o install-qt.sh https://raw.githubusercontent.com/qbs/qbs/faa280045d783d2fbe815fa83c8c143faf02ecf7/scripts/install-qt.sh
+  chmod +x install-qt.sh
+  # See below URL for examples on what packages are available for a version
+  # https://download.qt.io/online/qtsdkrepository/mac_x64/desktop/qt5_598/qt.qt5.598.clang_64/
+  # Should agree with Pipfile PyQt5 version and path in auto-build.sh
+  ./install-qt.sh --directory /usr/local/opt/Qt --version 5.10.1 qtbase qttools
+  ln -s /usr/local/opt/Qt/5.10.1/clang_64 /usr/local/opt/qt5
+}
+
+install_pideps(){
+  # To prevent python pipenv error during init script
+  # "Click will abort further execution because Python 3 was configured to use ASCII as encoding for the environment."
+  # https://click.palletsprojects.com/en/7.x/python3/
+  export LC_ALL=en_US.UTF-8
+  export LANG=en_US.UTF-8
+
+  echo "==> Installing Python dependencies"
+  # Seems like we need to go to the knossos folder before running pipenv
+  pip3 install -U pip pipenv wheel macholib
+  pipenv install --system --deploy
+}
+
+## END FUNCTIONS ##
+
+install_clitools
+
+install_nvm
+
+install_yarn
+
+install_homebrew
+
+install_brews
 
 # If we don't delete qmake, PyInstaller detects this Qt installation and uses its libraries instead of PyQt5's
 # which then leads to a crash because PyQt5 isn't compatible with the version we install.
@@ -53,39 +118,14 @@ brew install p7zip ninja
 mkdir /tmp/prov
 cd /tmp/prov
 
-# We need Python 3.6 since that's the latest version PyInstaller supports.
-# Update: PyInstaller supports 3.7 now but couldn't get things to cooperate with it.
-# Also this needs to agree with the version in the Pipfile.
-echo "==> Installing Python 3.6.8"
-curl -so python.pkg "https://www.python.org/ftp/python/3.6.8/python-3.6.8-macosx10.9.pkg"
-sudo installer -store -pkg python.pkg -target /
+install_python
 
-export PATH="/Library/Frameworks/Python.framework/Versions/3.6/bin:$PATH"
+install_SDL2
 
-echo "==> Installing SDL2"
-curl -so SDL2.dmg "https://libsdl.org/release/SDL2-2.0.12.dmg"
-
-dev="$(hdiutil attach SDL2.dmg | tail -n1 | awk '{ print $3 }')"
-sudo cp -a "$dev/SDL2.framework" /Library/Frameworks
-hdiutil detach "$dev"
-rm SDL2.dmg
-
-# Visit script URL for info.  From 'Cubes' (qbs)
-echo "==> Installing Qt5 (base and tools)"
-curl -o install-qt.sh https://code.qt.io/cgit/qbs/qbs.git/plain/scripts/install-qt.sh
-chmod +x install-qt.sh
-# See below URL for examples on what packages are available for a version
-# https://download.qt.io/online/qtsdkrepository/mac_x64/desktop/qt5_598/qt.qt5.598.clang_64/
-# Should agree with Pipfile PyQt5 version and path in auto-build.sh
-./install-qt.sh --directory /usr/local/opt/Qt --version 5.10.1 qtbase qttools
-ln -s /usr/local/opt/Qt/5.10.1/clang_64 /usr/local/opt/qt5
+install_qt5
 
 echo "==> Cleanup"
-cd ..
-rm -r prov
+cd "$base"
+rm -r /tmp/prov
 
-echo "==> Installing Python dependencies"
-# Seems like we need to go to the knossos folder before running pipenv
-cd /opt/knossos
-pip3 install -U pip pipenv wheel macholib
-pipenv install --system --deploy
+install_pideps


### PR DESCRIPTION
This updates the mac build ecosystem to use more shared code between the Travis and Vagrant VM provisioners.  It also moves the OS for the Vagrant build to macOS 10.13.  Finally it changes the Travis ecosystem to use a manually installed Qt5 instead of the one included in Homebrew, which I suspect is the cause of the current release build problems.  The builds made on the Vagrant 10.13 setup work just the same as the ones on the 10.12 setup, so I have high hopes the Travis builds might actually work after this change too.