### PR TITLE
Add Yarn path to macOS auto-build.sh PATH var

### DIFF
--- a/releng/macos/auto-build.sh
+++ b/releng/macos/auto-build.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-export PATH="/usr/local/bin:$PATH:/Library/Frameworks/Python.framework/Versions/3.6/bin:/usr/local/opt/qt5/bin"
+export PATH="/usr/local/bin:$HOME/.yarn/bin:$HOME/.config/yarn/global/node_modules/.bin:$PATH:/Library/Frameworks/Python.framework/Versions/3.6/bin:/usr/local/opt/qt5/bin"
 export LANG="en_US.UTF-8"
 
 # ninja ends up in a reconfigure loop here without this


### PR DESCRIPTION
Not seemingly necessary on the VM process since we run it in a full login terminal, but looks like this is needed for the Travis side so let's add it where we add all the other Mac specific paths.