### PR TITLE
Workaround for the current mod list issue

### DIFF
--- a/knossos/util.py
+++ b/knossos/util.py
@@ -389,7 +389,7 @@ def _get_download_chunk_size():
         return min(int(center.settings['download_bandwidth'] / 2), DEFAULT_CHUNK_SIZE)
 
 
-def download(link, dest, headers=None, random_ua=False, timeout=60, continue_=False):
+def download(link, dest, headers=None, random_ua=False, timeout=60, continue_=False, get_etag=False):
     global HTTP_SESSION, DL_POOL, _DL_CANCEL
 
     if headers is None:
@@ -466,6 +466,9 @@ def download(link, dest, headers=None, random_ua=False, timeout=60, continue_=Fa
                 })
             except Exception:
                 pass
+
+    if get_etag:
+        return result.headers.get('etag', True)
 
     return True
 

--- a/knossos/windows.py
+++ b/knossos/windows.py
@@ -507,6 +507,9 @@ class HellWindow(Window):
                         mv['installed'] = False
                         mv['dev_mode'] = False
 
+                    if self._mod_filter != 'develop':
+                        del mv['packages']
+
                     item['versions'].append(mv)
 
                 if item['installed'] and not item['versions'][0]['installed']:
@@ -555,6 +558,7 @@ class HellWindow(Window):
             if filter_ in ('home', 'explore', 'develop'):
                 updated_mods = self._compute_mod_list_diff(result)
                 mod_order = [item['id'] for item in result]
+
                 self.browser_ctrl.bridge.updateModlist.emit(json.dumps(updated_mods), filter_, mod_order)
 
     def show_indicator(self):


### PR DESCRIPTION
I've removed the package list from the mod list data that's passed to the JS UI since it's never used in the UI and takes up a lot of space. As a result, the mod list works again and the explore tab loads much faster.

I've also added caching for the mod repo. It now only updates the local `mods.json` repo if an updated version is available. That should make Knossos the whole "Fetching modlist..." step faster and might make mod list loading a bit more reliable (I've seen various issues around this in the automated error reports).