### PR TITLE
Fix uninstall process

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -188,7 +188,7 @@ with open('build.ninja', 'w') as stream:
         n.comment('Win32')
 
         if check_module('PyInstaller', required=False):
-            pyinstaller = 'cmd /C "cd releng\\windows && %s"' % cmd2str([sys.executable, '-O', '-mPyInstaller', '-d', '--distpath=.\\dist', '--workpath=.\\build', 'Knossos.spec', '-y'])
+            pyinstaller = 'cmd /C "cd releng\\windows && %s"' % cmd2str([sys.executable, '-O', '-mPyInstaller', '-d', 'all', '--distpath=.\\dist', '--workpath=.\\build', 'Knossos.spec', '-y'])
             n.rule('pyinstaller', pyinstaller, 'PACKAGE', pool='console')
             n.build('pyi', 'pyinstaller', ['resources'] + SRC_FILES)
 

--- a/releng/windows/nsis/installer.nsi
+++ b/releng/windows/nsis/installer.nsi
@@ -53,7 +53,8 @@ Var StartMenuFolder
 
 LangString DESC_desk_icon ${LANG_ENGLISH} "Creates a shortcut icon on your desktop."
 LangString DESC_fso_support ${LANG_ENGLISH} "Allows you to open fso:// links with Knossos."
-LangString DESC_un_settings ${LANG_ENGLISH} "Removes all settings and cached files that Knossos creates."
+LangString DESC_un_kn_settings ${LANG_ENGLISH} "Removes your Knossos settings, but not the Knossos library."
+LangString DESC_un_fso_settings ${LANG_ENGLISH} "Removes your pilots, game saves, and game configuration, but not the Knossos library."
 
 Section
     SetOutPath "$INSTDIR"
@@ -120,10 +121,16 @@ Section "-Uninstall"
     ${EndIf}
 SectionEnd
 
-Section "un.Remove Settings" un_settings
+Section "un.Remove Knossos Settings" un_kn_settings
     SetShellVarContext current
     RMDir /r "$APPDATA\knossos"
     RMDir /r "$LOCALAPPDATA\Knossos"
+    SetShellVarContext all
+SectionEnd
+
+Section /o "un.Remove Game Settings and Saves" un_fso_settings
+    SetShellVarContext current
+    RMDir /r "$APPDATA\HardLightProductions"
     SetShellVarContext all
 SectionEnd
 
@@ -133,5 +140,9 @@ SectionEnd
 !insertmacro MUI_FUNCTION_DESCRIPTION_END
 
 !insertmacro MUI_UNFUNCTION_DESCRIPTION_BEGIN
-    !insertmacro MUI_DESCRIPTION_TEXT ${un_settings} $(DESC_un_settings)
+    !insertmacro MUI_DESCRIPTION_TEXT ${un_kn_settings} $(DESC_un_kn_settings)
+!insertmacro MUI_UNFUNCTION_DESCRIPTION_END
+
+!insertmacro MUI_UNFUNCTION_DESCRIPTION_BEGIN
+    !insertmacro MUI_DESCRIPTION_TEXT ${un_fso_settings} $(DESC_un_fso_settings)
 !insertmacro MUI_UNFUNCTION_DESCRIPTION_END

--- a/releng/windows/nsis/installer.nsi
+++ b/releng/windows/nsis/installer.nsi
@@ -53,7 +53,7 @@ Var StartMenuFolder
 
 LangString DESC_desk_icon ${LANG_ENGLISH} "Creates a shortcut icon on your desktop."
 LangString DESC_fso_support ${LANG_ENGLISH} "Allows you to open fso:// links with Knossos."
-LangString DESC_un_settings ${LANG_ENGLISH} "Removes all settings and cached files which were created by Knossos."
+LangString DESC_un_settings ${LANG_ENGLISH} "Removes all settings and cached files that Knossos creates."
 
 Section
     SetOutPath "$INSTDIR"
@@ -98,9 +98,9 @@ Section "fso:// Support" fso_support
     WriteRegStr HKCR "fso\shell\open\command" "Default" "$\"$INSTDIR\Knossos.exe$\" $\"%1$\""
 SectionEnd
 
-Section "Uninstall"
+Section "-Uninstall"
     !insertmacro MUI_STARTMENU_GETFOLDER Application $StartMenuFolder
-    SetShellVarContext all  # Install for all users
+    SetShellVarContext all  # Uninstall for all users
 
     Delete "$SMPROGRAMS\$StartMenuFolder\Knossos.lnk"
     Delete "$SMPROGRAMS\$StartMenuFolder\Uninstall.lnk"
@@ -121,7 +121,10 @@ Section "Uninstall"
 SectionEnd
 
 Section "un.Remove Settings" un_settings
+    SetShellVarContext current
     RMDir /r "$APPDATA\knossos"
+    RMDir /r "$LOCALAPPDATA\Knossos"
+    SetShellVarContext all
 SectionEnd
 
 !insertmacro MUI_FUNCTION_DESCRIPTION_BEGIN


### PR DESCRIPTION
Make these changes:
- Remove knossos data folders from both Roaming and Local AppData folders.
- Update `configure.py` to be compatible with PyInstaller 3.5+ by inserting `all` after the `-d` (debug) flag.  See https://pyinstaller.readthedocs.io/en/stable/CHANGES.html#id17
- Make "Uninstall" a hidden section, so that it's no longer optional in the uninstaller.
- Slight revision to the description for "Remove Settings".

Known issues:
- AppData folder removal is for the current user only. Not sure how big of an issue this is. Getting it to work for all users will require more work and may be tricky.

EDIT: This PR is intended to fix issue #198 .