### PR TITLE
Fix SDL2.framework usage

### DIFF
--- a/knossos/clibs.py
+++ b/knossos/clibs.py
@@ -126,7 +126,7 @@ def init_sdl():
             # Load SDL
             if sys.platform == 'darwin' and hasattr(sys, 'frozen'):
                 try:
-                    sdl = load_lib('../Frameworks/SDL2.framework/SDL2')
+                    sdl = load_lib('../Frameworks/SDL2.framework/Versions/A/SDL2')
                 except Exception:
                     logging.exception('Failed to load bundled SDL2!')
 

--- a/releng/macos/Knossos.spec
+++ b/releng/macos/Knossos.spec
@@ -134,4 +134,4 @@ app = BUNDLE(exe,
               'CFBundleShortVersionString': version
             })
 
-copytree(os.path.dirname(sdl2_path), os.path.join(DISTPATH, 'Knossos.app/Contents/Frameworks/SDL2.framework'))
+copytree(os.path.dirname(sdl2_path), os.path.join(DISTPATH, 'Knossos.app/Contents/Frameworks/SDL2.framework'), symlinks=True)


### PR DESCRIPTION
Make the following changes for macOS:
1. Preserve symlinks when copying SDL2.framework into the Knossos.app bundle
2. Use the correct path to the SDL2 shared library inside SDL2.framework The new path matches the one that FSO uses as found with the output of `otool -L` on the FSO binary.

This PR is intended to fix Issue #197.