### PR TITLE
fix(client): add explicit cast to string const (C++11)

### DIFF
--- a/packages/build-tools/cmd/dyn_loader.go
+++ b/packages/build-tools/cmd/dyn_loader.go
@@ -195,7 +195,7 @@ func genLoader(headerFile, dynHeader string) error {
 		loader.WriteString("!" + name)
 	}
 	loader.WriteString(") {\n")
-	loader.WriteString(`  *error = "One or more functions could not be found!";` + "\n")
+	loader.WriteString(`  *error = (char*) "One or more functions could not be found!";` + "\n")
 	loader.WriteString("  return false;\n")
 	loader.WriteString("}\n")
 


### PR DESCRIPTION
Allows compilation with `-Werror` on newer versions of gcc/clang.