### PR TITLE
(assorted) Windows fixes

### DIFF
--- a/task.bat
+++ b/task.bat
@@ -3,6 +3,7 @@
 setlocal
 cd %~dp0
 
+set "PATH=%CD%\third_party\go\bin;%PATH%"
 go version > NUL 2>&1
 if errorlevel 1 goto :fix_go
 goto :build

--- a/tasks.star
+++ b/tasks.star
@@ -197,10 +197,9 @@ def configure():
 
     prepend_path("third_party/go/bin")
     prepend_path("third_party/protoc-dist")
-    prepend_path("third_party/nodejs/bin")
-    prepend_path(".tools")
 
     if OS == "windows":
+        prepend_path("third_party/nodejs")
         build_tool_cmds = [
             "touch .tools/tool.exe.rebuild",
             "echo \"Can't rebuild tool in one step on Windows. The old build was removed, please run the same command " +
@@ -208,10 +207,13 @@ def configure():
             "exit 1",
         ]
     else:
+        prepend_path("third_party/nodejs/bin")
         build_tool_cmds = [
             "cd packages/build-tools",
             "go build -o ../../.tools/tool%s" % binext,
         ]
+
+    prepend_path(".tools")
 
     task(
         "build-tool",


### PR DESCRIPTION
Some fixes for faulty SFX extraction (race condition), not picking up the installed go toolchain in task.bat, and node.js having an idiosyncratic tarball layout across platforms.