### PR TITLE
POSIX sh

### DIFF
--- a/packages/libarchive/msys2-build.sh
+++ b/packages/libarchive/msys2-build.sh
@@ -1,13 +1,9 @@
-#!/bin/bash
+#!/bin/sh
 
-set -eo pipefail
+set -e
 
-cd "$(dirname "$0")"
-
-cd ../..
-if [ ! -d build/libarchive ]; then
-	mkdir -p build/libarchive
-fi
+cd "$(dirname "$0")"/../..
+mkdir -p build/libarchive
 cd build/libarchive
 
 export PATH="/mingw64/bin:$PATH"

--- a/packages/libarchive/unix-build.sh
+++ b/packages/libarchive/unix-build.sh
@@ -1,13 +1,9 @@
-#!/bin/bash
+#!/bin/sh
 
-set -eo pipefail
+set -e
 
-cd "$(dirname "$0")"
-
-cd ../..
-if [ ! -d build/libarchive ]; then
-	mkdir -p build/libarchive
-fi
+cd "$(dirname "$0")"/../..
+mkdir -p build/libarchive
 cd build/libarchive
 
 if [ ! -f CMakeCache.txt ]; then

--- a/task.sh
+++ b/task.sh
@@ -1,19 +1,20 @@
-#!/bin/bash
+#!/bin/sh
 
-set -eo pipefail
+set -e
 
 cd "$(dirname "$0")"
 
-if !which go > /dev/null 2>&1; then
-	echo "Please install the Golang toolchain and run this script again."
-	exit 1
+if ! command -v go > /dev/null 2>&1; then
+    echo "Please install the Golang toolchain and run this script again."
+    exit 1
 fi
 
 if [ ! -f .tools/tool ]; then
-    cd packages/build-tools
-    echo "Building build-tools"
-    go build -o ../../.tools/tool
-    cd ../..
+    (
+        cd packages/build-tools
+        echo "Building build-tools..."
+        go build -o ../../.tools/tool
+    )
 fi
 
 exec ./.tools/tool task "$@"


### PR DESCRIPTION
A series of changes to increase POSIX compliance/simplify shell scripting.
Some notes:
- No need to check if a directory exists before `mkdir` if you use the `-p` flag. It acts as a no-op if the dir does not exist.
- No need to call out to bash every time you invoke MSYS. It's important for the first run (and for some $PATH shenanigans in one case) only
- I didn't merge unix-build and windows-build, but they could be merged as they differ by one line. Just make one a wrapper for the other.
- I haven't tested on FreeBSD yet, but the shell script portions will work without installing Bash from Ports at least.