### PR TITLE
 Fix array index out of bounds issue in joystick mapping

### DIFF
--- a/knossos/runner.py
+++ b/knossos/runner.py
@@ -213,7 +213,7 @@ class Fs2Watcher(threading.Thread):
                     logging.info('Mapping joystick %s => %s (many matched)', sel_guid, joy[0]['guid'])
 
                     cfg['fso']['joystick_guid'] = joy[0]['guid']
-                elif len(candidates) == 0:
+                elif len(candidates) > 0:
                     if len(flags['joysticks']) > sel_id:
                         logging.warning('Mapping joystick %s => %s (based on index)', sel_guid, candidates[sel_id]['guid'])
 


### PR DESCRIPTION
When no joystick candidates existed, joystick mapping tried to assign a joystick based on the previous used index. Since the candidates array was empty, this failed. 

Hopefully, closes scp-fs2open/fs2open.github.com#4338 

(re-creating the request because I made a few git mistakes in the previous one)