### PR TITLE
fix broken settings screen on macOS

### DIFF
--- a/knossos/launcher.py
+++ b/knossos/launcher.py
@@ -222,6 +222,11 @@ def run_knossos():
             logging.exception('Failed to load local mod list!')
             center.mods.clear()
 
+    # Init SDL at the start to load up video modes, which only works
+    # on the main thread with some OSes (macOS in particular)
+    from knossos import clibs
+    clibs.init_sdl()
+
     center.main_win.start_init()
 
     app.exec_()


### PR DESCRIPTION
SDL video initialization only appears to work on the main thread, so preload the video modes at launch instead of when entering settings. Fixes broken settings on Intel Macs and hard crash on Apple Silicon.

Also tested to work on Linux.