### PR TITLE
fix handling of invalid nebula login

### DIFF
--- a/knossos/web.py
+++ b/knossos/web.py
@@ -1323,6 +1323,7 @@ class WebBridge(QtCore.QObject):
             return True
         else:
             QtWidgets.QMessageBox.critical(None, 'Knossos', 'Login failed.')
+            return False
 
     @QtCore.Slot(result=bool)
     def nebLogout(self):


### PR DESCRIPTION
If the nebula login credentials were incorrect a popup would indicate that the login failed but the ui would say that you were logged in. A fatal exception dialog would also appear due to missing the return value.