### PR TITLE
tweak progress bar on main window to be useful

### DIFF
--- a/knossos/progress.py
+++ b/knossos/progress.py
@@ -311,10 +311,7 @@ class Task(QtCore.QObject):
 
                 self.progress.emit((total / max(1, len(self._slot_prog)), self._slot_prog, self.title))
             else:
-                if self._work_count == 1:
-                    self.progress.emit((prog, {}, self.title))
-                else:
-                    self.progress.emit((self._res_count / self._work_count, {}, self.title))
+                self.progress.emit((prog, {}, text))
 
     def post(self, result):
         with self._result_lock:

--- a/knossos/tasks.py
+++ b/knossos/tasks.py
@@ -56,7 +56,7 @@ class FetchTask(progress.MultistepTask):
         pass
 
     def work1(self, part):
-        progress.update(0.1, 'Fetching "%s"...' % part)
+        progress.update(0.01, '')
 
         try:
             data = Repo()
@@ -104,6 +104,7 @@ class FetchTask(progress.MultistepTask):
                     os.unlink(dest_path + '.tmp')
 
                 with open(dest_path, 'r') as dest:
+                    progress.update(0.9, 'loading, please wait...')
                     data.parse(dest.read())
 
                 self._public = data

--- a/knossos/util.py
+++ b/knossos/util.py
@@ -446,8 +446,8 @@ def download(link, dest, headers=None, random_ua=False, timeout=60, continue_=Fa
                         text = format_bytes(speed) + '/s, '
                         text += time.strftime('%M:%S', time.gmtime((size - by_done) / speed)) + ' left'
                     else:
-                        p = 0
-                        text = ''
+                        p = 1
+                        text = format_bytes(sc.get_speed()) + '/s, <unknown>'
                     progress.update(p, text)
 
                 if _DL_CANCEL.is_set():

--- a/knossos/windows.py
+++ b/knossos/windows.py
@@ -605,7 +605,8 @@ class HellWindow(Window):
             integration.current.set_progress(pi[0])
 
         if len(task.mods) == 0 and self._prg_visible:
-            self.win.progressBar.setValue(pi[0] * 100)
+            self.win.progressLabel.setText(task.title + ' ' + pi[2])
+            self.win.progressBar.setValue(int(pi[0] * 100))
 
     def _forget_task(self, task):
         tid = id(task)


### PR DESCRIPTION
Main window progress bar should now show proper progress for the active task with multi-step tasks and also provide the status text updates on the label instead of it being hidden. This primarily addresses the large amount of "nothing happening" when fetching the mod list on slower internet connections.

Also include download speed progress indicator, even when content-length header is not available to show duration.